### PR TITLE
Support changing self username on code-pair

### DIFF
--- a/webapp/src/components/NavBar/NameTextInput.tsx
+++ b/webapp/src/components/NavBar/NameTextInput.tsx
@@ -1,0 +1,36 @@
+import React, { useCallback, useRef } from 'react';
+import { useSelector } from 'react-redux';
+import TextField from '@material-ui/core/TextField';
+
+import { AppState } from 'app/rootReducer';
+import usePeer from 'hooks/usePeer';
+
+
+export default function NameTextInput() {
+  const client = useSelector((state: AppState) => state.docState.client);
+  const inputRef = useRef<HTMLInputElement>(null);
+
+  const { activePeers } = usePeer();
+
+  const onBlur = useCallback(() => {
+    // TODO: UpdateMetadate with peerSlice action.
+  }, []);
+
+  if (!client) {
+    // NOTE: We use null as an exception to prevent component from rendering.
+    return null;
+  }
+
+  return (
+    <>
+      <TextField 
+        ref={inputRef}
+        id="standard-basic" 
+        label="My name is..."
+        value={activePeers.filter((peer) => peer.isMine)[0]?.metadata?.username ?? ''}
+        variant="standard"
+        onBlur={onBlur}
+      />
+    </>
+  );
+}

--- a/webapp/src/components/NavBar/index.tsx
+++ b/webapp/src/components/NavBar/index.tsx
@@ -5,6 +5,7 @@ import AppBar from '@material-ui/core/AppBar';
 import Toolbar from '@material-ui/core/Toolbar';
 import Typography from '@material-ui/core/Typography';
 import PeerGroup from 'components/NavBar/PeerGroup';
+import NameTextInput from 'components/NavBar/NameTextInput';
 import ShareButton from 'components/NavBar/ShareButton';
 import NetworkButton from 'components/NavBar/NetworkButton';
 
@@ -27,6 +28,8 @@ const useStyles = makeStyles((theme: Theme) =>
     items: {
       display: 'flex',
       '& > *': {
+        display: 'flex',
+        alignItems: 'center',
         margin: theme.spacing(1),
       },
     },
@@ -48,6 +51,7 @@ function MenuAppBar() {
           <NetworkButton />
           <div className={classes.grow} />
           <div className={classes.items}>
+            <NameTextInput />
             <ShareButton />
             <PeerGroup />
           </div>


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

#### What this PR does / why we need it?
Current username consists of anonymous animal name. This is useful, but sometimes users may need to change their name to identify theirselves.

#### Any background context you want to provide?
This is draft PR of this issue, as I am faced with a few problems.

1. `Client.UpdateMetadata` is necessary for this process, maybe in the `peerSlice`. Guess some kind of `UpdateMetadata` action should change the username when the textInput of the username is onBlur, but is it related to the PR #143 ? and need to wait until that is completed?
2. Any user process opinions. onClick event of clicking the avatar is already assigned to the action of showing userlist view, so I'm not sure when to show this text input. Or just always-showing mode of text input is enough?

Any review on code or opinions would be very helpful. Thanks.


#### What are the relevant tickets?
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #129 

### Checklist
- [x] Added relevant tests or not required
- [x] Didn't break anything
