### PR TITLE
Adjust position of vim command. #148

### DIFF
--- a/webapp/src/components/Editor/CodeEditor/index.scss
+++ b/webapp/src/components/Editor/CodeEditor/index.scss
@@ -56,3 +56,16 @@
 .CodeMirror pre.CodeMirror-placeholder {
   color: gray;
 }
+
+/* 
+ * Make vim command visible.
+ * issue ref https://github.com/yorkie-team/codepair/issues/148  
+ */
+.CodeMirror-dialog { 
+  &.CodeMirror-dialog-bottom {
+    position: absolute;
+    z-index: 2;
+    padding-left: 32px;
+    bottom: 10px;
+  }
+}


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

#### What this PR does / why we need it?

Adjust position of vim command that were partially hided.

#### Any background context you want to provide?

Add `postion: abosolute; z-index: 2;` for not overlapping `codes`.

|Before adding z-index|After adding z-index|
|:-------:|:-------:|
|![스크린샷 2022-01-24 오후 2 54 14](https://user-images.githubusercontent.com/40482274/150736411-f97819e4-c60b-4ac5-a3be-209c0a4e55ab.png)|![스크린샷 2022-01-24 오후 2 54 06](https://user-images.githubusercontent.com/40482274/150736433-795d9853-bc87-46bc-bf2c-f9c53e616091.png)|


#### What are the relevant tickets?
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #148

### Checklist
- [X] Added relevant tests or not required
- [X] Didn't break anything
