### PR TITLE
Fix sidebar shrinks

### DIFF
--- a/webapp/src/components/Editor/Editor.tsx
+++ b/webapp/src/components/Editor/Editor.tsx
@@ -21,6 +21,7 @@ const useStyles = makeStyles(() =>
     },
     editor: {
       width: `calc(100% - ${SIDEBAR_WIDTH}px)`,
+      flex: '0 0 auto',
     },
     codeEditor: {
       width: '100%',


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

#### What this PR does / why we need it?

Fix shrinking sidebar when type fully in one line. 

|Before Fix|After Fix|
|:-------:|:-------:|
|![화면 기록 2022-01-28 오후 4 38 22 mov](https://user-images.githubusercontent.com/40482274/151506436-fb48ad57-505b-4601-ac08-2db475a89b1b.gif)|![화면 기록 2022-01-28 오후 4 36 22 mov](https://user-images.githubusercontent.com/40482274/151506306-c72d66ed-4ddc-4c24-9710-28067c1efaa8.gif)|



#### Any background context you want to provide?

`flex: 0 0 auto` make editor area not shrink or grow.

#### What are the relevant tickets?
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #167 

### Checklist
- [X] Added relevant tests or not required
- [X] Didn't break anything
