### PR TITLE
Add snapshot event observer to document

### DIFF
--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -26,10 +26,6 @@ services:
     container_name: 'yorkie'
     command: [
       'server',
-      '--backend-snapshot-threshold',
-      '2',
-      '--backend-snapshot-interval',
-      '2',
     ]
     restart: always
     ports:

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -26,6 +26,10 @@ services:
     container_name: 'yorkie'
     command: [
       'server',
+      '--backend-snapshot-threshold',
+      '2',
+      '--backend-snapshot-interval',
+      '2',
     ]
     restart: always
     ports:

--- a/package.json
+++ b/package.json
@@ -62,6 +62,8 @@
   "scripts": {
     "start": "REACT_APP_GIT_HASH=`git rev-parse --short HEAD` react-scripts start",
     "build": "REACT_APP_GIT_HASH=`git rev-parse --short HEAD` react-scripts build",
+    "start-win": "set REACT_APP_GIT_HASH=`git rev-parse --short HEAD` && react-scripts start",
+    "build-win": "set REACT_APP_GIT_HASH=`git rev-parse --short HEAD` && react-scripts build",
     "test": "react-scripts test",
     "eject": "react-scripts eject",
     "lint": "eslint . --ext .ts,.tsx",

--- a/package.json
+++ b/package.json
@@ -62,8 +62,8 @@
   "scripts": {
     "start": "REACT_APP_GIT_HASH=`git rev-parse --short HEAD` react-scripts start",
     "build": "REACT_APP_GIT_HASH=`git rev-parse --short HEAD` react-scripts build",
-    "start-win": "set REACT_APP_GIT_HASH=`git rev-parse --short HEAD` && react-scripts start",
-    "build-win": "set REACT_APP_GIT_HASH=`git rev-parse --short HEAD` && react-scripts build",
+    "start:win": "set REACT_APP_GIT_HASH=`git rev-parse --short HEAD` && react-scripts start",
+    "build:win": "set REACT_APP_GIT_HASH=`git rev-parse --short HEAD` && react-scripts build",
     "test": "react-scripts test",
     "eject": "react-scripts eject",
     "lint": "eslint . --ext .ts,.tsx",


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

#### What this PR does / why we need it?

When a client receives a snapshot, `doc.root` is replaced by the snapshot.
It is not detected by the remote change obsever, causing problems with
synchronization.

By adding snapshot event observer to document, value of the editor is
synced and the onChange handler re-setted for the replaced new root.


#### Any background context you want to provide?


#### What are the relevant tickets?
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes https://github.com/yorkie-team/yorkie-js-sdk/issues/347

### Checklist
- [x] Added relevant tests or not required
- [x] Didn't break anything
