### PR TITLE
Usage of presence canvas for drawing shapes

### DIFF
--- a/src/components/Editor/DrawingBoard/Canvas/Board.ts
+++ b/src/components/Editor/DrawingBoard/Canvas/Board.ts
@@ -1,3 +1,4 @@
+/* eslint-disable @typescript-eslint/no-unused-vars */
 import { ToolType, Color } from 'features/boardSlices';
 import { Point, Shape, Root } from 'features/docSlices';
 import EventDispatcher from 'utils/eventDispatcher';
@@ -228,24 +229,26 @@ export default class Board extends EventDispatcher {
   }
 
   updateMetadata(peerKey: string, metadata: Metadata) {
-    this.clear(this.lowerWrapper);
-
-    this.update((root: Root) => {
-      this.drawAll(root.shapes);
-    });
+    this.clear(this.upperWrapper);
 
     this.metadataMap.set(peerKey, JSON.parse(metadata.board || '{}'));
 
     for (const boardMetadata of this.metadataMap.values()) {
-      const { eraserPoints, line } = boardMetadata;
+      const { eraserPoints, line, rect } = boardMetadata;
       if (eraserPoints && eraserPoints.length > 0) {
-        drawEraser(this.lowerWrapper.getContext(), {
+        drawEraser(this.upperWrapper.getContext(), {
           type: 'eraser',
           points: eraserPoints,
         });
       }
       if (line && line.points.length > 0) {
-        drawTrace(this.lowerWrapper.getContext(), line);
+        drawTrace(this.upperWrapper.getContext(), line);
+      }
+      if (rect && rect.box.height !== 0 && rect.box.width !== 0) {
+        drawRect(this.upperWrapper.getContext(), rect);
+      }
+      if (!eraserPoints && !line && !rect) {
+        this.clear(this.upperWrapper);
       }
     }
   }

--- a/src/components/Editor/DrawingBoard/Canvas/Board.ts
+++ b/src/components/Editor/DrawingBoard/Canvas/Board.ts
@@ -4,7 +4,7 @@ import EventDispatcher from 'utils/eventDispatcher';
 import { Metadata } from 'features/peerSlices';
 
 import CanvasWrapper from './CanvasWrapper';
-import { drawLine, drawEraser } from './line';
+import { drawLine, drawEraser, drawTrace } from './line';
 import { drawRect } from './rect';
 import { addEvent, removeEvent, touchy, TouchyEvent } from './dom';
 import { Worker, NoneWorker, LineWorker, EraserWorker, RectWorker, SelectorWorker, BoardMetadata } from './Worker';
@@ -215,7 +215,9 @@ export default class Board extends EventDispatcher {
     touchy(this.upperWrapper.getCanvas(), removeEvent, 'mousemove', this.onMouseMove);
     this.dragStatus = DragStatus.Stop;
 
-    this.worker.mouseup();
+    this.worker.mouseup((boardMetadata: BoardMetadata) => {
+      this.emit('mousedown', boardMetadata);
+    });
     this.emit('mouseup');
   }
 
@@ -235,12 +237,15 @@ export default class Board extends EventDispatcher {
     this.metadataMap.set(peerKey, JSON.parse(metadata.board || '{}'));
 
     for (const boardMetadata of this.metadataMap.values()) {
-      const { eraserPoints } = boardMetadata;
+      const { eraserPoints, line } = boardMetadata;
       if (eraserPoints && eraserPoints.length > 0) {
         drawEraser(this.lowerWrapper.getContext(), {
           type: 'eraser',
           points: eraserPoints,
         });
+      }
+      if (line && line.points.length > 0) {
+        drawTrace(this.lowerWrapper.getContext(), line);
       }
     }
   }

--- a/src/components/Editor/DrawingBoard/Canvas/Worker/EraserWorker.ts
+++ b/src/components/Editor/DrawingBoard/Canvas/Worker/EraserWorker.ts
@@ -2,7 +2,7 @@ import { Root, Point, Box } from 'features/docSlices';
 import { ToolType } from 'features/boardSlices';
 import Board from 'components/Editor/DrawingBoard/Canvas/Board';
 import { fixEraserPoint } from '../line';
-import Worker, { MouseDownCallback, MouseMoveCallback } from './Worker';
+import Worker, { MouseDownCallback, MouseMoveCallback, MouseUpCallback } from './Worker';
 import { compressPoints, checkLineIntersection, isInnerBox, isSelectable } from '../utils';
 import * as scheduler from '../scheduler';
 
@@ -91,8 +91,9 @@ class EraserWorker extends Worker {
     });
   }
 
-  mouseup() {
+  mouseup(callback: MouseUpCallback) {
     this.flushTask();
+    callback({});
   }
 
   flushTask() {

--- a/src/components/Editor/DrawingBoard/Canvas/Worker/LineWorker.ts
+++ b/src/components/Editor/DrawingBoard/Canvas/Worker/LineWorker.ts
@@ -30,40 +30,12 @@ class LineWorker extends Worker {
   }
 
   mousedown(point: Point): void {
-    // let timeTicket: TimeTicket;
-
     this.previewLine = createLine(point, this.options?.color!);
-    // this.update((root: Root) => {
-    //   const shape = createLine(point, this.options?.color!);
-    //   root.shapes.push(shape);
-
-    //   const lastShape = root.shapes.getLast();
-    //   timeTicket = lastShape.getID();
-    // });
-
-    // this.createID = timeTicket!;
   }
 
   mousemove(point: Point, callback: MouseMoveCallback) {
     this.previewLine.points.push(point);
     callback({ line: { ...this.previewLine } });
-    // scheduler.reserveTask(point, (tasks: Array<scheduler.Task>) => {
-    //   const points = compressPoints(tasks);
-
-    //   if (tasks.length < 2) {
-    //     return;
-    //   }
-
-    //   this.update((root: Root) => {
-    //     const lastShape = this.getElementByID(root, this.createID!);
-    //     if (!lastShape) {
-    //       return;
-    //     }
-
-    //     lastShape.points.push(...points);
-    //     this.board.drawAll(root.shapes);
-    //   });
-    // });
   }
 
   mouseup(callback: MouseUpCallback) {
@@ -73,7 +45,6 @@ class LineWorker extends Worker {
   }
 
   flushTask() {
-    // scheduler.flushTask();
     if (this.previewLine.points.length > 0) {
       this.update((root: Root) => {
         this.previewLine.points = compressPoints(this.previewLine.points);
@@ -84,24 +55,6 @@ class LineWorker extends Worker {
         this.board.drawAll(root.shapes);
       });
     }
-
-    // this.update((root: Root) => {
-    //   if (!this.createID) {
-    //     return;
-    //   }
-
-    //   const shape = this.getElementByID(root, this.createID!);
-    //   if (!shape) {
-    //     return;
-    //   }
-
-    //   // When erasing a line, it checks that the lines overlap, so do not save if there are two points below
-    //   if (shape.points.length < 2) {
-    //     this.deleteByID(root, this.createID!);
-    //   }
-
-    //   this.board.drawAll(root.shapes);
-    // });
   }
 }
 

--- a/src/components/Editor/DrawingBoard/Canvas/Worker/LineWorker.ts
+++ b/src/components/Editor/DrawingBoard/Canvas/Worker/LineWorker.ts
@@ -1,11 +1,11 @@
 import { TimeTicket } from 'yorkie-js-sdk';
-import { Root, Point } from 'features/docSlices';
+import { Root, Point, Line } from 'features/docSlices';
 import { ToolType } from 'features/boardSlices';
 import Board from 'components/Editor/DrawingBoard/Canvas/Board';
 import { createLine } from '../line';
-import Worker, { Options } from './Worker';
+import Worker, { MouseMoveCallback, MouseUpCallback, Options } from './Worker';
 import { compressPoints } from '../utils';
-import * as scheduler from '../scheduler';
+// import * as scheduler from '../scheduler';
 
 class LineWorker extends Worker {
   type = ToolType.Line;
@@ -16,70 +16,92 @@ class LineWorker extends Worker {
 
   private createID?: TimeTicket;
 
+  private previewLine: Omit<Line, 'getID'>;
+
   constructor(update: Function, board: Board, options: Options) {
     super(options);
     this.update = update;
     this.board = board;
+    this.previewLine = {
+      type: 'line',
+      color: this.options!.color,
+      points: [],
+    };
   }
 
   mousedown(point: Point): void {
-    let timeTicket: TimeTicket;
+    // let timeTicket: TimeTicket;
 
-    this.update((root: Root) => {
-      const shape = createLine(point, this.options?.color!);
-      root.shapes.push(shape);
+    this.previewLine = createLine(point, this.options?.color!);
+    // this.update((root: Root) => {
+    //   const shape = createLine(point, this.options?.color!);
+    //   root.shapes.push(shape);
 
-      const lastShape = root.shapes.getLast();
-      timeTicket = lastShape.getID();
-    });
+    //   const lastShape = root.shapes.getLast();
+    //   timeTicket = lastShape.getID();
+    // });
 
-    this.createID = timeTicket!;
+    // this.createID = timeTicket!;
   }
 
-  mousemove(point: Point) {
-    scheduler.reserveTask(point, (tasks: Array<scheduler.Task>) => {
-      const points = compressPoints(tasks);
+  mousemove(point: Point, callback: MouseMoveCallback) {
+    this.previewLine.points.push(point);
+    callback({ line: { ...this.previewLine } });
+    // scheduler.reserveTask(point, (tasks: Array<scheduler.Task>) => {
+    //   const points = compressPoints(tasks);
 
-      if (tasks.length < 2) {
-        return;
-      }
+    //   if (tasks.length < 2) {
+    //     return;
+    //   }
 
-      this.update((root: Root) => {
-        const lastShape = this.getElementByID(root, this.createID!);
-        if (!lastShape) {
-          return;
-        }
+    //   this.update((root: Root) => {
+    //     const lastShape = this.getElementByID(root, this.createID!);
+    //     if (!lastShape) {
+    //       return;
+    //     }
 
-        lastShape.points.push(...points);
-        this.board.drawAll(root.shapes);
-      });
-    });
+    //     lastShape.points.push(...points);
+    //     this.board.drawAll(root.shapes);
+    //   });
+    // });
   }
 
-  mouseup() {
+  mouseup(callback: MouseUpCallback) {
     this.flushTask();
+    this.previewLine = { ...this.previewLine, points: [] };
+    callback({});
   }
 
   flushTask() {
-    scheduler.flushTask();
+    // scheduler.flushTask();
+    if (this.previewLine.points.length > 0) {
+      this.update((root: Root) => {
+        this.previewLine.points = compressPoints(this.previewLine.points);
+        root.shapes.push(this.previewLine as Line);
 
-    this.update((root: Root) => {
-      if (!this.createID) {
-        return;
-      }
+        const lastShape = root.shapes.getLast();
+        this.createID = lastShape.getID();
+        this.board.drawAll(root.shapes);
+      });
+    }
 
-      const shape = this.getElementByID(root, this.createID!);
-      if (!shape) {
-        return;
-      }
+    // this.update((root: Root) => {
+    //   if (!this.createID) {
+    //     return;
+    //   }
 
-      // When erasing a line, it checks that the lines overlap, so do not save if there are two points below
-      if (shape.points.length < 2) {
-        this.deleteByID(root, this.createID!);
-      }
+    //   const shape = this.getElementByID(root, this.createID!);
+    //   if (!shape) {
+    //     return;
+    //   }
 
-      this.board.drawAll(root.shapes);
-    });
+    //   // When erasing a line, it checks that the lines overlap, so do not save if there are two points below
+    //   if (shape.points.length < 2) {
+    //     this.deleteByID(root, this.createID!);
+    //   }
+
+    //   this.board.drawAll(root.shapes);
+    // });
   }
 }
 

--- a/src/components/Editor/DrawingBoard/Canvas/Worker/RectWorker.ts
+++ b/src/components/Editor/DrawingBoard/Canvas/Worker/RectWorker.ts
@@ -3,8 +3,8 @@ import { Root, Point, Rect } from 'features/docSlices';
 import { ToolType } from 'features/boardSlices';
 import Board from 'components/Editor/DrawingBoard/Canvas/Board';
 import { createRect, adjustRectBox } from '../rect';
-import Worker, { Options } from './Worker';
-import * as scheduler from '../scheduler';
+import Worker, { MouseMoveCallback, MouseUpCallback, Options } from './Worker';
+// import * as scheduler from '../scheduler';
 
 class RectWorker extends Worker {
   type = ToolType.Rect;
@@ -15,53 +15,51 @@ class RectWorker extends Worker {
 
   private createID?: TimeTicket;
 
+  private previewRect: Omit<Rect, 'getID'>;
+
   constructor(update: Function, board: Board, options: Options) {
     super(options);
     this.update = update;
     this.board = board;
+    this.previewRect = {
+      type: 'rect',
+      color: this.options!.color,
+      box: {
+        x: 0,
+        y: 0,
+        width: 0,
+        height: 0,
+      },
+      points: [],
+    };
   }
 
   mousedown(point: Point): void {
-    let timeTicket: TimeTicket;
-
-    this.update((root: Root) => {
-      const shape = createRect(point, this.options!);
-      root.shapes.push(shape);
-
-      const lastShape = root.shapes.getLast();
-      timeTicket = lastShape.getID();
-    });
-
-    this.createID = timeTicket!;
+    this.previewRect = createRect(point, this.options!);
   }
 
-  mousemove(point: Point) {
-    scheduler.reserveTask(point, (tasks: Array<scheduler.Task>) => {
-      if (tasks.length < 2) {
-        return;
-      }
-
-      this.update((root: Root) => {
-        const lastPoint = tasks[tasks.length - 1];
-        const lastShape = this.getElementByID(root, this.createID!) as Rect;
-        if (!lastShape) {
-          return;
-        }
-
-        const box = adjustRectBox(lastShape, lastPoint);
-        lastShape.box = box;
-
-        this.board.drawAll(root.shapes);
-      });
-    });
+  mousemove(point: Point, callback: MouseMoveCallback) {
+    const box = adjustRectBox(this.previewRect as Rect, point);
+    this.previewRect.box = box;
+    callback({ rect: { ...this.previewRect } });
   }
 
-  mouseup() {
+  mouseup(callback: MouseUpCallback) {
     this.flushTask();
+    this.previewRect = { ...this.previewRect, box: { x: 0, y: 0, height: 0, width: 0 }, points: [] };
+    callback({});
   }
 
   flushTask() {
-    scheduler.flushTask();
+    if (this.previewRect.box.width !== 0 && this.previewRect.box.height !== 0) {
+      this.update((root: Root) => {
+        root.shapes.push(this.previewRect as Rect);
+
+        const lastShape = root.shapes.getLast();
+        this.createID = lastShape.getID();
+        this.board.drawAll(root.shapes);
+      });
+    }
   }
 }
 

--- a/src/components/Editor/DrawingBoard/Canvas/Worker/Worker.ts
+++ b/src/components/Editor/DrawingBoard/Canvas/Worker/Worker.ts
@@ -1,16 +1,20 @@
 import { TimeTicket } from 'yorkie-js-sdk';
 import { ToolType, Color } from 'features/boardSlices';
-import { Root, Shape, Point } from 'features/docSlices';
+import { Root, Shape, Point, Line, Rect } from 'features/docSlices';
 
 export type Options = { color: Color };
 
 export type BoardMetadata = {
   eraserPoints?: Point[];
+  line?: Omit<Line, 'getID'>;
+  rect?: Omit<Rect, 'getID'>;
 };
 
 export type MouseDownCallback = (boardMetadata: BoardMetadata) => void;
 
 export type MouseMoveCallback = (boardMetadata: BoardMetadata) => void;
+
+export type MouseUpCallback = (boardMetadata: BoardMetadata) => void;
 
 abstract class Worker {
   constructor(options?: Options) {
@@ -27,7 +31,7 @@ abstract class Worker {
 
   abstract mousemove(point: Point, callback?: MouseMoveCallback): void;
 
-  abstract mouseup(): void;
+  abstract mouseup(callback?: MouseUpCallback): void;
 
   abstract flushTask(): void;
 

--- a/src/components/Editor/DrawingBoard/Canvas/line.ts
+++ b/src/components/Editor/DrawingBoard/Canvas/line.ts
@@ -28,6 +28,20 @@ export function createEraserLine(point: Point): EraserLine {
 }
 
 /**
+ * drawTrace draws a trace of the line
+ */
+export function drawTrace(context: CanvasRenderingContext2D, line: CanvasLine) {
+  const { points, color } = line;
+  context.strokeStyle = color;
+  context.beginPath();
+  context.moveTo(points[0].x, points[0].y);
+  for (let i = 1; i < points.length; i += 1) {
+    context.lineTo(points[i].x, points[i].y);
+  }
+  context.stroke();
+}
+
+/**
  * drawLine draws a line with bezier curves.
  */
 export function drawLine(context: CanvasRenderingContext2D, line: CanvasLine) {

--- a/src/components/Editor/DrawingBoard/Canvas/rect.ts
+++ b/src/components/Editor/DrawingBoard/Canvas/rect.ts
@@ -6,6 +6,8 @@ export interface RectOptions {
   color: Color;
 }
 
+type CanvasRect = Pick<Rect, 'type' | 'color' | 'box'>;
+
 /**
  * Create the basic object of the rect with point.
  */
@@ -26,7 +28,7 @@ export function createRect(point: Point, options: RectOptions): Rect {
 /**
  * Draw a rect on the canvas.
  */
-export function drawRect(context: CanvasRenderingContext2D, rect: Rect) {
+export function drawRect(context: CanvasRenderingContext2D, rect: CanvasRect) {
   context.save();
   context.strokeStyle = rect.color;
   context.strokeRect(rect.box.x, rect.box.y, rect.box.width, rect.box.height);


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

#### What this PR does / why we need it?
I have changed how users draw shapes by using presence canvas(=upper canvas)

If a user starts drawing a shape, instead of updating the shape to the document directly, I have made the shape be updated to user's presence instead. The shapes drawn in the user's presence is drawn on the upper canvas.

As soon as the user finishes drawing(mouse up or mouse out), the shape in the presence is transmitted to the document directly. To lessen the burden of the document storing unnecessarily many points, I have called compressPoints at that moment, thus reducing the amount of data stored in the document.


#### Any background context you want to provide?

The usage of presence canvas for drawing on canvas is also used in Toonie. The implementation of the drawing methods is quite similar to [toonie](https://github.com/yorkie-team/toonie)


#### What are the relevant tickets?
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

### Checklist
- [x] Added relevant tests or not required
- [x] Didn't break anything
