### PR TITLE
Modify/click link check

### DIFF
--- a/src/components/Editor/CodeEditor/index.tsx
+++ b/src/components/Editor/CodeEditor/index.tsx
@@ -158,8 +158,6 @@ export default function CodeEditor({ forwardedRef }: CodeEditorProps) {
         const pos = editor.coordsChar({ left: event.clientX, top: event.clientY });
         const token = editor.getTokenAt(pos);
 
-        console.log(token);
-
         if (token.type?.includes('link')) {
           window.open(token.string, token.string);
         }

--- a/src/components/Editor/CodeEditor/index.tsx
+++ b/src/components/Editor/CodeEditor/index.tsx
@@ -158,7 +158,9 @@ export default function CodeEditor({ forwardedRef }: CodeEditorProps) {
         const pos = editor.coordsChar({ left: event.clientX, top: event.clientY });
         const token = editor.getTokenAt(pos);
 
-        if (token.type === 'link') {
+        console.log(token);
+
+        if (token.type?.includes('link')) {
           window.open(token.string, token.string);
         }
       }


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

#### What this PR does / why we need it?

Resolved the problem that the token type is displayed differently when clicking on the link

Links can be roughly connected to other places, so the type can come out.

1. If the link text exists at the beginning of the document: `link`
2. If present in link format: `link link`
3. If it exists inside a specific text: `variable-2 link`

Allows all links to be checked.

#### Any background context you want to provide?


#### What are the relevant tickets?
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

### Checklist
- [x] Added relevant tests or not required
- [x] Didn't break anything
