### PR TITLE
support localStorage sync

### DIFF
--- a/src/app/rootReducer.ts
+++ b/src/app/rootReducer.ts
@@ -6,6 +6,7 @@ import settingReducer from 'features/settingSlices';
 import boardReducer from 'features/boardSlices';
 import linkReducer from 'features/linkSlices';
 import messageReducer from 'features/messageSlices';
+import navReducer from 'features/navSlices';
 
 const rootReducer = combineReducers({
   docState: docReducer,
@@ -14,6 +15,7 @@ const rootReducer = combineReducers({
   boardState: boardReducer,
   linkState: linkReducer,
   messageState: messageReducer,
+  navState: navReducer,
 });
 
 export type AppState = ReturnType<typeof rootReducer>;

--- a/src/components/NavBar/index.tsx
+++ b/src/components/NavBar/index.tsx
@@ -9,7 +9,7 @@ import PeerGroup from 'components/NavBar/PeerGroup';
 import ShareButton from 'components/NavBar/ShareButton';
 import NetworkButton from 'components/NavBar/NetworkButton';
 import { useDispatch } from 'react-redux';
-import { toggleLinkTab } from 'features/linkSlices';
+import { toggleTab } from 'features/navSlices';
 
 const useStyles = makeStyles((theme: Theme) =>
   createStyles({
@@ -59,7 +59,7 @@ function MenuAppBar() {
           <IconButton
             size="small"
             onClick={() => {
-              dispatch(toggleLinkTab('all'));
+              dispatch(toggleTab());
             }}
             className={classes.iconButton}
           >

--- a/src/components/SideBar/index.tsx
+++ b/src/components/SideBar/index.tsx
@@ -64,14 +64,13 @@ import {
   setLinkFileLink,
   setLinkName,
   setLinkOpens,
-  setTabValue,
-  TabValueType,
   toggleFavorite,
   toggleLinkOpen,
 } from 'features/linkSlices';
 import { TabContext, TabList, TabPanel } from '@material-ui/lab';
 import { Theme } from 'features/settingSlices';
 import { showMessage } from 'features/messageSlices';
+import { NavTabType, toggleLinkTab } from 'features/navSlices';
 
 interface SideBarProps {
   open: boolean;
@@ -1257,16 +1256,17 @@ TabPanelHeader.defaultProps = {
 export function SideBar() {
   const dispatch = useDispatch();
   const linkState = useSelector((state: AppState) => state.linkState);
+  const navState = useSelector((state: AppState) => state.navState);
   const headings = useSelector((state: AppState) => state.docState.headings);
   const menu = useSelector((state: AppState) => state.settingState.menu);
   const favorites = useSelector(favoriteSelector);
-  const open = useSelector((state: AppState) => state.linkState.openTab);
+  const open = navState.openTab;
   const linkRef = useRef<boolean>(false);
   const classes = useStyles({ open });
   const { docKey } = useParams<{ docKey: string }>();
 
-  const handleChange = (event: ChangeEvent<{}>, newValue: TabValueType) => {
-    dispatch(setTabValue(newValue));
+  const handleChange = (event: ChangeEvent<{}>, newValue: NavTabType) => {
+    dispatch(toggleLinkTab(newValue));
   };
 
   const showTreeNode = useCallback(
@@ -1325,8 +1325,8 @@ export function SideBar() {
   }, [docKey, showTreeNode, linkState.groups]);
 
   return (
-    <Drawer variant="permanent" className={classes.drawer} open={linkState.openTab}>
-      <TabContext value={linkState.openTabValue}>
+    <Drawer variant="permanent" className={classes.drawer} open={open}>
+      <TabContext value={navState.openTabValue}>
         <Box>
           <TabList
             onChange={handleChange}
@@ -1340,7 +1340,7 @@ export function SideBar() {
                   <EventNote /> Notes
                 </TabLabel>
               }
-              value="links"
+              value="notes"
             />
             <Tab
               label={
@@ -1352,7 +1352,7 @@ export function SideBar() {
             />
           </TabList>
         </Box>
-        <TabPanel value="links">
+        <TabPanel value="notes">
           <TabPanelHeader>
             <Star
               fontSize="small"

--- a/src/features/linkSlices.ts
+++ b/src/features/linkSlices.ts
@@ -93,6 +93,15 @@ const linkSlice = createSlice({
   initialState: initialLinkState,
 
   reducers: {
+    refreshStorage(state) {
+      const newValue = SettingModel.getValue(state);
+
+      state.openTab = newValue.openTab;
+      state.openTabValue = newValue.openTabValue;
+      state.favorite = newValue.favorite;
+      state.groups = newValue.groups;
+      state.opens = newValue.opens;
+    },
     toggleFavorite(state, action: PayloadAction<string | LinkItemType>) {
       const { payload } = action;
 
@@ -156,6 +165,10 @@ const linkSlice = createSlice({
     toggleLinkOpen(state, action: PayloadAction<string>) {
       const { payload } = action;
       state.opens[payload] = !state.opens[payload];
+
+      if (state.opens[payload] === false) {
+        delete state.opens[payload];
+      }
 
       SettingModel.setValue(state);
     },
@@ -403,6 +416,7 @@ export function recentFavoriteSelector(count: number = 10) {
 }
 
 export const {
+  refreshStorage,
   copyMarkdownTextForGroup,
   toggleFavorite,
   setTabValue,

--- a/src/features/linkSlices.ts
+++ b/src/features/linkSlices.ts
@@ -27,14 +27,10 @@ export interface OpenState {
 }
 
 export interface LinkState {
-  openTab: boolean;
-  openTabValue: TabValueType;
   opens: OpenState;
   favorite: (string | LinkItemType)[];
   groups: GroupType[];
 }
-
-export type TabValueType = 'all' | 'links' | 'toc';
 
 function traverse(parent: any, data: any[], callback: (item: any, parent: any, depth: number) => void, depth = 0) {
   data.forEach((item) => {
@@ -60,8 +56,6 @@ function copyTextToClipboard(text: string) {
 const SettingModel = new BrowserStorage<LinkState>('$$codepair$$link');
 
 const initialLinkState: LinkState = SettingModel.getValue({
-  openTab: false,
-  openTabValue: 'links',
   favorite: [],
   groups: [
     {
@@ -96,8 +90,6 @@ const linkSlice = createSlice({
     refreshStorage(state) {
       const newValue = SettingModel.getValue(state);
 
-      state.openTab = newValue.openTab;
-      state.openTabValue = newValue.openTabValue;
       state.favorite = newValue.favorite;
       state.groups = newValue.groups;
       state.opens = newValue.opens;
@@ -125,40 +117,6 @@ const linkSlice = createSlice({
 
       state.favorite = favorite;
 
-      SettingModel.setValue(state);
-    },
-    toggleLinkTab(state, action: PayloadAction<TabValueType>) {
-      const tabValue = action.payload || 'links';
-
-      if (tabValue === 'all') {
-        if (state.openTab) {
-          state.openTab = false;
-          SettingModel.setValue(state);
-          return;
-        }
-
-        state.openTab = true;
-        SettingModel.setValue(state);
-
-        return;
-      }
-
-      if (state.openTabValue === tabValue) {
-        state.openTab = !state.openTab;
-        SettingModel.setValue(state);
-        return;
-      }
-
-      state.openTab = true;
-      state.openTabValue = tabValue;
-
-      SettingModel.setValue(state);
-    },
-
-    setTabValue(state, action: PayloadAction<TabValueType>) {
-      const tabValue = action.payload || 'links';
-
-      state.openTabValue = tabValue;
       SettingModel.setValue(state);
     },
 
@@ -419,8 +377,6 @@ export const {
   refreshStorage,
   copyMarkdownTextForGroup,
   toggleFavorite,
-  setTabValue,
-  toggleLinkTab,
   toggleLinkOpen,
   setLinkName,
   updateLinkNameWithHeading,

--- a/src/features/navSlices.ts
+++ b/src/features/navSlices.ts
@@ -1,0 +1,30 @@
+import { createSlice, PayloadAction } from '@reduxjs/toolkit';
+
+export type NavTabType = 'notes' | 'toc';
+
+export interface NavState {
+  openTab: boolean;
+  openTabValue: NavTabType;
+}
+
+const initialNavState: NavState = {
+  openTab: false,
+  openTabValue: 'notes',
+};
+
+const navSlice = createSlice({
+  name: 'nav',
+  initialState: initialNavState,
+
+  reducers: {
+    toggleTab(state) {
+      state.openTab = !state.openTab;
+    },
+    toggleLinkTab(state, action: PayloadAction<NavTabType>) {
+      state.openTabValue = action.payload;
+    },
+  },
+});
+
+export const { toggleTab, toggleLinkTab } = navSlice.actions;
+export default navSlice.reducer;

--- a/src/pages/DocPage.tsx
+++ b/src/pages/DocPage.tsx
@@ -13,7 +13,7 @@ import { Snackbar } from '@material-ui/core';
 import { hideMessage } from 'features/messageSlices';
 import { Alert, SpeedDial, SpeedDialAction, SpeedDialIcon } from '@material-ui/lab';
 import { EventNote, QuestionAnswer, RecordVoiceOver } from '@material-ui/icons';
-import { recentFavoriteSelector } from 'features/linkSlices';
+import { recentFavoriteSelector, refreshStorage } from 'features/linkSlices';
 
 type DocPageProps = {
   docKey: string;
@@ -146,6 +146,7 @@ function SpeedDialPanel() {
 }
 
 export default function DocPage(props: RouteComponentProps<DocPageProps>) {
+  const dispatch = useDispatch();
   const openTab = useSelector((state: AppState) => state.linkState.openTab);
   const menu = useSelector((state: AppState) => state.settingState.menu);
   const classes = useStyles({
@@ -162,6 +163,12 @@ export default function DocPage(props: RouteComponentProps<DocPageProps>) {
       ReactGA.send('pageview');
     }
   }, [location]);
+
+  useEffect(() => {
+    window.addEventListener('storage', () => {
+      dispatch(refreshStorage());
+    });
+  }, [dispatch]);
 
   return (
     <div className={classes.root} data-theme={menu.theme}>

--- a/src/pages/DocPage.tsx
+++ b/src/pages/DocPage.tsx
@@ -147,7 +147,7 @@ function SpeedDialPanel() {
 
 export default function DocPage(props: RouteComponentProps<DocPageProps>) {
   const dispatch = useDispatch();
-  const openTab = useSelector((state: AppState) => state.linkState.openTab);
+  const openTab = useSelector((state: AppState) => state.navState.openTab);
   const menu = useSelector((state: AppState) => state.settingState.menu);
   const classes = useStyles({
     open: openTab,


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

#### What this PR does / why we need it?

Fixes an issue where data stored in local storage was not synchronized when multiple browser tabs were opened with a Codepair URL.

#### Any background context you want to provide?

The storage event is fired on the window when localStorage changes. 
It exclude synchronizing tab information because it changes the way the browser syncs.

#### What are the relevant tickets?
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

### Checklist
- [x] Added relevant tests or not required
- [x] Didn't break anything
