### PR TITLE
Change `yorkie-js-sdk` version to latest for `x-shard-key` exposure

### DIFF
--- a/docker/envoy.yaml
+++ b/docker/envoy.yaml
@@ -30,7 +30,7 @@ static_resources:
                 allow_origin_string_match:
                 - prefix: "*"
                 allow_methods: GET, PUT, DELETE, POST, OPTIONS
-                allow_headers: keep-alive,user-agent,cache-control,content-type,content-transfer-encoding,custom-header-1,x-accept-content-transfer-encoding,x-accept-response-streaming,x-user-agent,x-grpc-web,grpc-timeout,authorization
+                allow_headers: keep-alive,user-agent,cache-control,content-type,content-transfer-encoding,custom-header-1,x-accept-content-transfer-encoding,x-accept-response-streaming,x-user-agent,x-grpc-web,grpc-timeout,authorization,x-yorkie-user-agent,x-shard-key
                 max_age: "1728000"
                 expose_headers: custom-header-1,grpc-status,grpc-message
           http_filters:

--- a/package-lock.json
+++ b/package-lock.json
@@ -52,7 +52,7 @@
         "redux": "^4.2.1",
         "tss-react": "^4.8.2",
         "unique-names-generator": "^4.7.1",
-        "yorkie-js-sdk": "^0.3.3"
+        "yorkie-js-sdk": "github:yorkie-team/yorkie-js-sdk#3b313a54eee2b20e0185f93813643479714a8244"
       },
       "devDependencies": {
         "@esbuild-plugins/node-globals-polyfill": "^0.2.3",
@@ -14798,14 +14798,22 @@
     },
     "node_modules/yorkie-js-sdk": {
       "version": "0.3.3",
-      "resolved": "https://registry.npmjs.org/yorkie-js-sdk/-/yorkie-js-sdk-0.3.3.tgz",
-      "integrity": "sha512-KrnFg9SEMOiADYQRVMdw/KxoGeFXUdRtKIW0AwJPs4bVSM1dQNl6V0buGZiFcBm+RHL+iUxdxnprY5x1RFjxlA==",
+      "resolved": "git+ssh://git@github.com/yorkie-team/yorkie-js-sdk.git#3b313a54eee2b20e0185f93813643479714a8244",
+      "integrity": "sha512-VTKyeYsODHDjOsjUyXlWe5KQrnpf4/IsHJCqV3cte1c9SDUbM5L4BDRkW6FAyTTc0o7b9DlGuRNJh02/MCQOCQ==",
+      "license": "Apache-2.0",
+      "workspaces": [
+        "examples/*"
+      ],
       "dependencies": {
         "@types/google-protobuf": "^3.15.5",
         "@types/long": "^4.0.1",
         "google-protobuf": "^3.19.4",
         "grpc-web": "^1.3.1",
         "long": "^5.2.0"
+      },
+      "engines": {
+        "node": ">=16.0.0",
+        "npm": ">=7.1.0"
       }
     },
     "node_modules/zustand": {
@@ -25508,9 +25516,9 @@
       "dev": true
     },
     "yorkie-js-sdk": {
-      "version": "0.3.3",
-      "resolved": "https://registry.npmjs.org/yorkie-js-sdk/-/yorkie-js-sdk-0.3.3.tgz",
-      "integrity": "sha512-KrnFg9SEMOiADYQRVMdw/KxoGeFXUdRtKIW0AwJPs4bVSM1dQNl6V0buGZiFcBm+RHL+iUxdxnprY5x1RFjxlA==",
+      "version": "git+ssh://git@github.com/yorkie-team/yorkie-js-sdk.git#3b313a54eee2b20e0185f93813643479714a8244",
+      "integrity": "sha512-VTKyeYsODHDjOsjUyXlWe5KQrnpf4/IsHJCqV3cte1c9SDUbM5L4BDRkW6FAyTTc0o7b9DlGuRNJh02/MCQOCQ==",
+      "from": "yorkie-js-sdk@github:yorkie-team/yorkie-js-sdk#3b313a54eee2b20e0185f93813643479714a8244",
       "requires": {
         "@types/google-protobuf": "^3.15.5",
         "@types/long": "^4.0.1",

--- a/package.json
+++ b/package.json
@@ -55,7 +55,7 @@
     "redux": "^4.2.1",
     "tss-react": "^4.8.2",
     "unique-names-generator": "^4.7.1",
-    "yorkie-js-sdk": "^0.3.3"
+    "yorkie-js-sdk": "github:yorkie-team/yorkie-js-sdk#3b313a54eee2b20e0185f93813643479714a8244"
   },
   "devDependencies": {
     "@esbuild-plugins/node-globals-polyfill": "^0.2.3",


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

#### What this PR does / why we need it?

Change `yorkie-js-sdk` version to latest for `x-shard-key` exposure

#### Any background context you want to provide?

#### What are the relevant tickets?
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

### Checklist
- [x] Added relevant tests or not required
- [x] Didn't break anything
