### PR TITLE
Apply Integration of SDK and Admin RPC Server

### DIFF
--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -10,7 +10,6 @@ services:
     restart: always
     ports:
       - '8080:8080'
-      - '9090:9090'
       - '9901:9901'
     depends_on:
       - yorkie
@@ -31,4 +30,3 @@ services:
     ports:
       - '11101:11101'
       - '11102:11102'
-      - '11103:11103'

--- a/docker/envoy.yaml
+++ b/docker/envoy.yaml
@@ -5,7 +5,7 @@ admin:
 
 static_resources:
   listeners:
-  - name: yorkie_listener
+  - name: yorkie_rpc_listener
     address:
       socket_address: { address: 0.0.0.0, port_value: 8080 }
     filter_chains:
@@ -22,7 +22,7 @@ static_resources:
               routes:
               - match: { prefix: "/" }
                 route:
-                  cluster: yorkie_service
+                  cluster: yorkie_rpc_service
                   # https://github.com/grpc/grpc-web/issues/361
                   max_stream_duration:
                     grpc_timeout_header_max: 0s
@@ -30,39 +30,7 @@ static_resources:
                 allow_origin_string_match:
                 - prefix: "*"
                 allow_methods: GET, PUT, DELETE, POST, OPTIONS
-                allow_headers: keep-alive,user-agent,cache-control,content-type,content-transfer-encoding,custom-header-1,x-accept-content-transfer-encoding,x-accept-response-streaming,x-user-agent,x-grpc-web,grpc-timeout,authorization,x-yorkie-user-agent,x-shard-key
-                max_age: "1728000"
-                expose_headers: custom-header-1,grpc-status,grpc-message
-          http_filters:
-          - name: envoy.filters.http.grpc_web
-          - name: envoy.filters.http.cors
-          - name: envoy.filters.http.router
-  - name: admin_listener
-    address:
-      socket_address: { address: 0.0.0.0, port_value: 9090 }
-    filter_chains:
-    - filters:
-      - name: envoy.filters.network.http_connection_manager
-        typed_config:
-          "@type": type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager
-          stat_prefix: ingress_http
-          route_config:
-            name: local_route
-            virtual_hosts:
-            - name: local_service
-              domains: ["*"]
-              routes:
-              - match: { prefix: "/" }
-                route:
-                  cluster: admin_service
-                  # https://github.com/grpc/grpc-web/issues/361
-                  max_stream_duration:
-                    grpc_timeout_header_max: 0s
-              cors:
-                allow_origin_string_match:
-                - prefix: "*"
-                allow_methods: GET, PUT, DELETE, POST, OPTIONS
-                allow_headers: keep-alive,user-agent,cache-control,content-type,content-transfer-encoding,custom-header-1,x-accept-content-transfer-encoding,x-accept-response-streaming,x-user-agent,x-grpc-web,grpc-timeout,authorization
+                allow_headers: keep-alive,user-agent,cache-control,content-type,content-transfer-encoding,custom-header-1,x-accept-content-transfer-encoding,x-accept-response-streaming,x-api-key,x-shard-key,x-user-agent,x-grpc-web,grpc-timeout,authorization,x-yorkie-user-agent
                 max_age: "1728000"
                 expose_headers: custom-header-1,grpc-status,grpc-message
           http_filters:
@@ -70,7 +38,7 @@ static_resources:
           - name: envoy.filters.http.cors
           - name: envoy.filters.http.router
   clusters:
-  - name: yorkie_service
+  - name: yorkie_rpc_service
     connect_timeout: 0.25s
     type: logical_dns
     http2_protocol_options: {}
@@ -89,22 +57,3 @@ static_resources:
               socket_address:
                 address: host.docker.internal
                 port_value: 11101
-  - name: admin_service
-    connect_timeout: 0.25s
-    type: logical_dns
-    http2_protocol_options: {}
-    lb_policy: round_robin
-    # Input the address which envoy can connect to as a yorkie server.
-    # When you want envoy container to communicate with your host machine, you should set as the following
-    # - Windows/Mac: Input host.docker.internal
-    # - Linux: an IP address of the host machine or docker-0 interface or some addresses defined in extra hosts of docker-compose.yml
-    # you can simply use the yorkie container name(e.g. yorkie) in docker-compose whatever your OS is.
-    load_assignment:
-      cluster_name: admin_cluster
-      endpoints:
-      - lb_endpoints:
-        - endpoint:
-            address:
-              socket_address:
-                address: host.docker.internal
-                port_value: 11103


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

#### What this PR does / why we need it?

Apply changes in integration of SDK and Admin RPC Server made by: https://github.com/yorkie-team/yorkie/pull/532

Changes:

- Remove Admin RPC ports (11103, 9090) in docker-compose files.
- Remove Admin listener/cluster in envoy configuration files.
- Update listener/cluster naming in envoy configuration files.

#### Any background context you want to provide?


#### What are the relevant tickets?
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

### Checklist
- [x] Added relevant tests or not required
- [x] Didn't break anything
