### PR TITLE
fix to handle links with fragments

### DIFF
--- a/src/components/Editor/mime/text/md/CodeEditor/index.tsx
+++ b/src/components/Editor/mime/text/md/CodeEditor/index.tsx
@@ -717,7 +717,8 @@ export default function CodeEditor() {
         const token = editor.getTokenAt(pos);
 
         if (token.type?.includes('link')) {
-          window.open(token.string, token.string);
+          const link = (event.target as HTMLElement).textContent ?? token.string;
+          window.open(link, link);
         }
       }
     }) as any);


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

#### What this PR does / why we need it?
Fixes URL link navigation with fragments not working properly.

#### Any background context you want to provide?
In my opinion, when a link contains a fragment in the code mirror, it seems that we cannot retrieve the text including the fragment using `token.string`. However, since the entire link is wrapped in a link-type span element, I have made changes to extract the url from the element, enabling proper navigation to the correct link.

#### What are the relevant tickets?
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #248

### Checklist
- [x] Added relevant tests or not required
- [x] Didn't break anything
