### PR TITLE
Remove duplicated 'code' button from the toolbar

### DIFF
--- a/src/components/Editor/mime/text/md/CodeEditor/index.tsx
+++ b/src/components/Editor/mime/text/md/CodeEditor/index.tsx
@@ -451,7 +451,6 @@ export default function CodeEditor() {
         'bold',
         'italic',
         'strikethrough',
-        'code',
         'horizontal-rule',
         'quote',
         '|',


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

#### What this PR does / why we need it?
![스크린샷 2023-10-25 11 16 52](https://github.com/yorkie-team/codepair/assets/57996351/1333c1cb-bedc-4093-b956-476047528baf)
I've removed the 'code' button that was duplicated in the toolbar, alongside the text style option. This was done to address the issue of having the same option twice.
![스크린샷 2023-10-25 11 21 59](https://github.com/yorkie-team/codepair/assets/57996351/28882a9f-be9a-4ebd-b1c8-19b3bae1857f)


#### Any background context you want to provide?


#### What are the relevant tickets?
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

### Checklist
- [x] Added relevant tests or not required
- [x] Didn't break anything
