### PR TITLE
Add support for KaTex in Markdown Preview

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -34,6 +34,7 @@
 				"codemirror-toolbar": "^0.0.4",
 				"color": "^4.2.3",
 				"form-data": "^4.0.0",
+				"katex": "^0.16.9",
 				"lib0": "^0.2.88",
 				"lodash": "^4.17.21",
 				"match-sorter": "^6.3.3",
@@ -53,11 +54,15 @@
 				"react-social-login-buttons": "^3.9.1",
 				"react-use": "^17.5.0",
 				"redux-persist": "^6.0.0",
+				"rehype-katex": "^7.0.0",
+				"rehype-rewrite": "^4.0.2",
+				"remark-math": "^6.0.0",
 				"vite-plugin-package-version": "^1.1.0",
 				"yorkie-js-sdk": "^0.4.15-rc"
 			},
 			"devDependencies": {
 				"@types/color": "^3.0.6",
+				"@types/katex": "^0.16.7",
 				"@types/lodash": "^4.14.202",
 				"@types/randomcolor": "^0.5.9",
 				"@types/react": "^18.2.43",
@@ -2216,6 +2221,11 @@
 			"integrity": "sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==",
 			"dev": true
 		},
+		"node_modules/@types/katex": {
+			"version": "0.16.7",
+			"resolved": "https://registry.npmjs.org/@types/katex/-/katex-0.16.7.tgz",
+			"integrity": "sha512-HMwFiRujE5PjrgwHQ25+bsLJgowjGjm5Z8FVSf0N6PwgJrwxH0QxzHYDcKsTfV3wva0vzrpqMTJS2jXPr5BMEQ=="
+		},
 		"node_modules/@types/lodash": {
 			"version": "4.14.202",
 			"resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.202.tgz",
@@ -3022,6 +3032,14 @@
 			"funding": {
 				"type": "github",
 				"url": "https://github.com/sponsors/wooorm"
+			}
+		},
+		"node_modules/commander": {
+			"version": "8.3.0",
+			"resolved": "https://registry.npmjs.org/commander/-/commander-8.3.0.tgz",
+			"integrity": "sha512-OkTL9umf+He2DZkUq8f8J9of7yL6RJKI24dVITBmNfZBmri9zYZQrKkuXiKhyfPSu8tUhnVBB1iKXevvnlR4Ww==",
+			"engines": {
+				"node": ">= 12"
 			}
 		},
 		"node_modules/concat-map": {
@@ -3975,6 +3993,48 @@
 				"node": ">= 0.4"
 			}
 		},
+		"node_modules/hast-util-from-dom": {
+			"version": "5.0.0",
+			"resolved": "https://registry.npmjs.org/hast-util-from-dom/-/hast-util-from-dom-5.0.0.tgz",
+			"integrity": "sha512-d6235voAp/XR3Hh5uy7aGLbM3S4KamdW0WEgOaU1YoewnuYw4HXb5eRtv9g65m/RFGEfUY1Mw4UqCc5Y8L4Stg==",
+			"dependencies": {
+				"@types/hast": "^3.0.0",
+				"hastscript": "^8.0.0",
+				"web-namespaces": "^2.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/unified"
+			}
+		},
+		"node_modules/hast-util-from-dom/node_modules/hast-util-parse-selector": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/hast-util-parse-selector/-/hast-util-parse-selector-4.0.0.tgz",
+			"integrity": "sha512-wkQCkSYoOGCRKERFWcxMVMOcYE2K1AaNLU8DXS9arxnLOUEWbOXKXiJUNzEpqZ3JOKpnha3jkFrumEjVliDe7A==",
+			"dependencies": {
+				"@types/hast": "^3.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/unified"
+			}
+		},
+		"node_modules/hast-util-from-dom/node_modules/hastscript": {
+			"version": "8.0.0",
+			"resolved": "https://registry.npmjs.org/hastscript/-/hastscript-8.0.0.tgz",
+			"integrity": "sha512-dMOtzCEd3ABUeSIISmrETiKuyydk1w0pa+gE/uormcTpSYuaNJPbX1NU3JLyscSLjwAQM8bWMhhIlnCqnRvDTw==",
+			"dependencies": {
+				"@types/hast": "^3.0.0",
+				"comma-separated-tokens": "^2.0.0",
+				"hast-util-parse-selector": "^4.0.0",
+				"property-information": "^6.0.0",
+				"space-separated-tokens": "^2.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/unified"
+			}
+		},
 		"node_modules/hast-util-from-html": {
 			"version": "2.0.1",
 			"resolved": "https://registry.npmjs.org/hast-util-from-html/-/hast-util-from-html-2.0.1.tgz",
@@ -3986,6 +4046,21 @@
 				"parse5": "^7.0.0",
 				"vfile": "^6.0.0",
 				"vfile-message": "^4.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/unified"
+			}
+		},
+		"node_modules/hast-util-from-html-isomorphic": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/hast-util-from-html-isomorphic/-/hast-util-from-html-isomorphic-2.0.0.tgz",
+			"integrity": "sha512-zJfpXq44yff2hmE0XmwEOzdWin5xwH+QIhMLOScpX91e/NSGPsAzNCvLQDIEPyO2TXi+lBmU6hjLIhV8MwP2kw==",
+			"dependencies": {
+				"@types/hast": "^3.0.0",
+				"hast-util-from-dom": "^5.0.0",
+				"hast-util-from-html": "^2.0.0",
+				"unist-util-remove-position": "^5.0.0"
 			},
 			"funding": {
 				"type": "opencollective",
@@ -4201,6 +4276,21 @@
 			"integrity": "sha512-OGkAxX1Ua3cbcW6EJ5pT/tslVb90uViVkcJ4ZZIMW/R33DX/AkcJcRrPebPwJkHYwlDHXz4aIwvAAaAdtrACFA==",
 			"dependencies": {
 				"@types/hast": "^3.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/unified"
+			}
+		},
+		"node_modules/hast-util-to-text": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/hast-util-to-text/-/hast-util-to-text-4.0.0.tgz",
+			"integrity": "sha512-EWiE1FSArNBPUo1cKWtzqgnuRQwEeQbQtnFJRYV1hb1BWDgrAlBU0ExptvZMM/KSA82cDpm2sFGf3Dmc5Mza3w==",
+			"dependencies": {
+				"@types/hast": "^3.0.0",
+				"@types/unist": "^3.0.0",
+				"hast-util-is-element": "^3.0.0",
+				"unist-util-find-after": "^5.0.0"
 			},
 			"funding": {
 				"type": "opencollective",
@@ -4623,6 +4713,21 @@
 				"node": ">=6"
 			}
 		},
+		"node_modules/katex": {
+			"version": "0.16.9",
+			"resolved": "https://registry.npmjs.org/katex/-/katex-0.16.9.tgz",
+			"integrity": "sha512-fsSYjWS0EEOwvy81j3vRA8TEAhQhKiqO+FQaKWp0m39qwOzHVBgAUBIXWj1pB+O2W3fIpNa6Y9KSKCVbfPhyAQ==",
+			"funding": [
+				"https://opencollective.com/katex",
+				"https://github.com/sponsors/katex"
+			],
+			"dependencies": {
+				"commander": "^8.3.0"
+			},
+			"bin": {
+				"katex": "cli.js"
+			}
+		},
 		"node_modules/keyv": {
 			"version": "4.5.4",
 			"resolved": "https://registry.npmjs.org/keyv/-/keyv-4.5.4.tgz",
@@ -4885,6 +4990,24 @@
 				"devlop": "^1.0.0",
 				"mdast-util-from-markdown": "^2.0.0",
 				"mdast-util-to-markdown": "^2.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/unified"
+			}
+		},
+		"node_modules/mdast-util-math": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/mdast-util-math/-/mdast-util-math-3.0.0.tgz",
+			"integrity": "sha512-Tl9GBNeG/AhJnQM221bJR2HPvLOSnLE/T9cJI9tlc6zwQk2nPk/4f0cHkOdEixQPC/j8UtKDdITswvLAy1OZ1w==",
+			"dependencies": {
+				"@types/hast": "^3.0.0",
+				"@types/mdast": "^4.0.0",
+				"devlop": "^1.0.0",
+				"longest-streak": "^3.0.0",
+				"mdast-util-from-markdown": "^2.0.0",
+				"mdast-util-to-markdown": "^2.1.0",
+				"unist-util-remove-position": "^5.0.0"
 			},
 			"funding": {
 				"type": "opencollective",
@@ -5203,6 +5326,24 @@
 			"integrity": "sha512-cY5PzGcnULaN5O7T+cOzfMoHjBW7j+T9D2sucA5d/KbsBTPcYdebm9zUd9zzdgJGCwahV+/W78Z3nbulBYVbTw==",
 			"dependencies": {
 				"devlop": "^1.0.0",
+				"micromark-factory-space": "^2.0.0",
+				"micromark-util-character": "^2.0.0",
+				"micromark-util-symbol": "^2.0.0",
+				"micromark-util-types": "^2.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/unified"
+			}
+		},
+		"node_modules/micromark-extension-math": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/micromark-extension-math/-/micromark-extension-math-3.0.0.tgz",
+			"integrity": "sha512-iJ2Q28vBoEovLN5o3GO12CpqorQRYDPT+p4zW50tGwTfJB+iv/VnB6Ini+gqa24K97DwptMBBIvVX6Bjk49oyQ==",
+			"dependencies": {
+				"@types/katex": "^0.16.0",
+				"devlop": "^1.0.0",
+				"katex": "^0.16.0",
 				"micromark-factory-space": "^2.0.0",
 				"micromark-util-character": "^2.0.0",
 				"micromark-util-symbol": "^2.0.0",
@@ -6436,6 +6577,24 @@
 				"url": "https://jaywcjlove.github.io/#/sponsor"
 			}
 		},
+		"node_modules/rehype-katex": {
+			"version": "7.0.0",
+			"resolved": "https://registry.npmjs.org/rehype-katex/-/rehype-katex-7.0.0.tgz",
+			"integrity": "sha512-h8FPkGE00r2XKU+/acgqwWUlyzve1IiOKwsEkg4pDL3k48PiE0Pt+/uLtVHDVkN1yA4iurZN6UES8ivHVEQV6Q==",
+			"dependencies": {
+				"@types/hast": "^3.0.0",
+				"@types/katex": "^0.16.0",
+				"hast-util-from-html-isomorphic": "^2.0.0",
+				"hast-util-to-text": "^4.0.0",
+				"katex": "^0.16.0",
+				"unist-util-visit-parents": "^6.0.0",
+				"vfile": "^6.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/unified"
+			}
+		},
 		"node_modules/rehype-parse": {
 			"version": "9.0.0",
 			"resolved": "https://registry.npmjs.org/rehype-parse/-/rehype-parse-9.0.0.tgz",
@@ -6519,6 +6678,21 @@
 				"micromark-extension-gfm": "^3.0.0",
 				"remark-parse": "^11.0.0",
 				"remark-stringify": "^11.0.0",
+				"unified": "^11.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/unified"
+			}
+		},
+		"node_modules/remark-math": {
+			"version": "6.0.0",
+			"resolved": "https://registry.npmjs.org/remark-math/-/remark-math-6.0.0.tgz",
+			"integrity": "sha512-MMqgnP74Igy+S3WwnhQ7kqGlEerTETXMvJhrUzDikVZ2/uogJCb+WHUg97hK9/jcfc0dkD73s3LN8zU49cTEtA==",
+			"dependencies": {
+				"@types/mdast": "^4.0.0",
+				"mdast-util-math": "^3.0.0",
+				"micromark-extension-math": "^3.0.0",
 				"unified": "^11.0.0"
 			},
 			"funding": {
@@ -7115,6 +7289,19 @@
 				"@types/unist": "^3.0.0",
 				"unist-util-is": "^6.0.0",
 				"unist-util-visit-parents": "^6.0.0"
+			}
+		},
+		"node_modules/unist-util-find-after": {
+			"version": "5.0.0",
+			"resolved": "https://registry.npmjs.org/unist-util-find-after/-/unist-util-find-after-5.0.0.tgz",
+			"integrity": "sha512-amQa0Ep2m6hE2g72AugUItjbuM8X8cGQnFoHk0pGfrFeT9GZhzN5SW8nRsiGKK7Aif4CrACPENkA6P/Lw6fHGQ==",
+			"dependencies": {
+				"@types/unist": "^3.0.0",
+				"unist-util-is": "^6.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/unified"
 			}
 		},
 		"node_modules/unist-util-is": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -38,6 +38,7 @@
 		"codemirror-toolbar": "^0.0.4",
 		"color": "^4.2.3",
 		"form-data": "^4.0.0",
+		"katex": "^0.16.9",
 		"lib0": "^0.2.88",
 		"lodash": "^4.17.21",
 		"match-sorter": "^6.3.3",
@@ -57,11 +58,15 @@
 		"react-social-login-buttons": "^3.9.1",
 		"react-use": "^17.5.0",
 		"redux-persist": "^6.0.0",
+		"rehype-katex": "^7.0.0",
+		"rehype-rewrite": "^4.0.2",
+		"remark-math": "^6.0.0",
 		"vite-plugin-package-version": "^1.1.0",
 		"yorkie-js-sdk": "^0.4.15-rc"
 	},
 	"devDependencies": {
 		"@types/color": "^3.0.6",
+		"@types/katex": "^0.16.7",
 		"@types/lodash": "^4.14.202",
 		"@types/randomcolor": "^0.5.9",
 		"@types/react": "^18.2.43",

--- a/frontend/src/components/editor/Preview.tsx
+++ b/frontend/src/components/editor/Preview.tsx
@@ -6,6 +6,11 @@ import { CircularProgress, Stack } from "@mui/material";
 import { useEffect, useState } from "react";
 import "./editor.css";
 import { addSoftLineBreak } from "../../utils/document";
+import katex from "katex";
+import { getCodeString } from "rehype-rewrite";
+import remarkMath from "remark-math";
+import rehypeKatex from "rehype-katex";
+import "katex/dist/katex.min.css";
 
 function Preview() {
 	const currentTheme = useCurrentTheme();
@@ -48,6 +53,44 @@ function Preview() {
 				style: {
 					whiteSpace: "wrap !important",
 					WebkitUserModify: "read-only",
+				},
+			}}
+			remarkPlugins={[remarkMath]}
+			rehypePlugins={[rehypeKatex]}
+			components={{
+				code: ({ children = [], className, ...props }) => {
+					// https://www.npmjs.com/package/@uiw/react-markdown-preview#support-custom-katex-preview
+					if (typeof children === "string" && /^\$\$(.*)\$\$/.test(children)) {
+						const html = katex.renderToString(children.replace(/^\$\$(.*)\$\$/, "$1"), {
+							throwOnError: false,
+						});
+						return (
+							<code
+								dangerouslySetInnerHTML={{ __html: html }}
+								style={{ background: "transparent" }}
+							/>
+						);
+					}
+					const code =
+						props.node && props.node.children
+							? getCodeString(props.node.children)
+							: children;
+					if (
+						typeof code === "string" &&
+						typeof className === "string" &&
+						/^language-katex/.test(className.toLocaleLowerCase())
+					) {
+						const html = katex.renderToString(code, {
+							throwOnError: false,
+						});
+						return (
+							<code
+								style={{ fontSize: "150%" }}
+								dangerouslySetInnerHTML={{ __html: html }}
+							/>
+						);
+					}
+					return <code className={String(className)}>{children}</code>;
 				},
 			}}
 		/>


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

**What this PR does / why we need it**:

<img width="1431" alt="image" src="https://github.com/yorkie-team/codepair/assets/52884648/8a79b409-a721-4dab-a8b4-ae5c15914a90">


The Markdown Preview feature currently lacks support for rendering KaTex equations. It would be beneficial to add support for KaTex rendering in the Markdown Preview to enhance the user experience for users who need to include mathematical equations in their Markdown documents.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #165 

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```

**Additional documentation**:

<!--
This section can be blank if this pull request does not require a release note.

Please use the following format for linking documentation:
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```

**Checklist**:
- [x] Added relevant tests or not required
- [x] Didn't break anything
