### PR TITLE
Update Markdown Preview to Open URLs in New Tab

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -54,6 +54,7 @@
 				"react-social-login-buttons": "^3.9.1",
 				"react-use": "^17.5.0",
 				"redux-persist": "^6.0.0",
+				"rehype-external-links": "^3.0.0",
 				"rehype-katex": "^7.0.0",
 				"rehype-rewrite": "^4.0.2",
 				"remark-math": "^6.0.0",
@@ -4454,6 +4455,17 @@
 				"fast-loops": "^1.1.3"
 			}
 		},
+		"node_modules/is-absolute-url": {
+			"version": "4.0.1",
+			"resolved": "https://registry.npmjs.org/is-absolute-url/-/is-absolute-url-4.0.1.tgz",
+			"integrity": "sha512-/51/TKE88Lmm7Gc4/8btclNXWS+g50wXhYJq8HWIBAGUBnoAdRu1aXeh364t/O7wXDAcTJDP8PNuNKWUDWie+A==",
+			"engines": {
+				"node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
 		"node_modules/is-alphabetical": {
 			"version": "2.0.1",
 			"resolved": "https://registry.npmjs.org/is-alphabetical/-/is-alphabetical-2.0.1.tgz",
@@ -6554,6 +6566,23 @@
 				"hast-util-heading-rank": "^3.0.0",
 				"hast-util-is-element": "^3.0.0",
 				"unified": "^11.0.0",
+				"unist-util-visit": "^5.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/unified"
+			}
+		},
+		"node_modules/rehype-external-links": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/rehype-external-links/-/rehype-external-links-3.0.0.tgz",
+			"integrity": "sha512-yp+e5N9V3C6bwBeAC4n796kc86M4gJCdlVhiMTxIrJG5UHDMh+PJANf9heqORJbt1nrCbDwIlAZKjANIaVBbvw==",
+			"dependencies": {
+				"@types/hast": "^3.0.0",
+				"@ungap/structured-clone": "^1.0.0",
+				"hast-util-is-element": "^3.0.0",
+				"is-absolute-url": "^4.0.0",
+				"space-separated-tokens": "^2.0.0",
 				"unist-util-visit": "^5.0.0"
 			},
 			"funding": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -58,6 +58,7 @@
 		"react-social-login-buttons": "^3.9.1",
 		"react-use": "^17.5.0",
 		"redux-persist": "^6.0.0",
+		"rehype-external-links": "^3.0.0",
 		"rehype-katex": "^7.0.0",
 		"rehype-rewrite": "^4.0.2",
 		"remark-math": "^6.0.0",

--- a/frontend/src/components/editor/Preview.tsx
+++ b/frontend/src/components/editor/Preview.tsx
@@ -10,6 +10,7 @@ import katex from "katex";
 import { getCodeString } from "rehype-rewrite";
 import remarkMath from "remark-math";
 import rehypeKatex from "rehype-katex";
+import rehypeExternalLinks from "rehype-external-links";
 import "katex/dist/katex.min.css";
 
 function Preview() {
@@ -56,7 +57,7 @@ function Preview() {
 				},
 			}}
 			remarkPlugins={[remarkMath]}
-			rehypePlugins={[rehypeKatex]}
+			rehypePlugins={[rehypeKatex, [rehypeExternalLinks, { target: "_blank" }]]}
 			components={{
 				code: ({ children = [], className, ...props }) => {
 					// https://www.npmjs.com/package/@uiw/react-markdown-preview#support-custom-katex-preview


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

**What this PR does / why we need it**:

This PR updates the Markdown Preview feature to open URLs in a new tab when clicked, instead of opening in the current tab.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #161 

**Special notes for your reviewer**:

Previously, when a URL was clicked in the Markdown Preview, it would open in the current tab. To enhance user experience and navigation, this PR modifies the behavior to open clicked URLs in a new tab.

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```

**Additional documentation**:

<!--
This section can be blank if this pull request does not require a release note.

Please use the following format for linking documentation:
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```

**Checklist**:
- [x] Added relevant tests or not required
- [x] Didn't break anything
