### PR TITLE
Fix bug where selecting the document editing mode again deselects the mode

### DIFF
--- a/frontend/src/components/headers/DocumentHeader.tsx
+++ b/frontend/src/components/headers/DocumentHeader.tsx
@@ -77,6 +77,7 @@ function DocumentHeader() {
 	]);
 
 	const handleChangeMode = (newMode: EditorModeType) => {
+		if (!newMode) return;
 		dispatch(setMode(newMode));
 	};
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

**What this PR does / why we need it**:

This PR addresses a bug where clicking on the selected document editing mode again would deselect the mode, resulting in nothing being displayed. The fix ensures that selecting the editing mode multiple times does not inadvertently deselect the mode.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #150 

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```

**Additional documentation**:

<!--
This section can be blank if this pull request does not require a release note.

Please use the following format for linking documentation:
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```

**Checklist**:
- [x] Added relevant tests or not required
- [x] Didn't break anything
