### PR TITLE
Update 'Return to Workspace' Button Functionality and Visibility

### DIFF
--- a/frontend/src/components/headers/DocumentHeader.tsx
+++ b/frontend/src/components/headers/DocumentHeader.tsx
@@ -23,11 +23,13 @@ import { ActorID } from "yorkie-js-sdk";
 import { YorkieCodeMirrorPresenceType } from "../../utils/yorkie/yorkieSync";
 import ArrowBackIosNewIcon from "@mui/icons-material/ArrowBackIosNew";
 import { useNavigate } from "react-router-dom";
+import { selectWorkspace } from "../../store/workspaceSlice";
 
 function DocumentHeader() {
 	const dispatch = useDispatch();
 	const navigate = useNavigate();
 	const editorState = useSelector(selectEditor);
+	const workspaceState = useSelector(selectWorkspace);
 	const [
 		presenceList,
 		{
@@ -82,7 +84,7 @@ function DocumentHeader() {
 	};
 
 	const handleToPrevious = () => {
-		navigate(-1);
+		navigate(`/${workspaceState.data?.slug}`);
 	};
 
 	return (
@@ -90,11 +92,13 @@ function DocumentHeader() {
 			<Toolbar>
 				<Stack width="100%" direction="row" justifyContent="space-between">
 					<Stack direction="row" spacing={1} alignItems="center">
-						<Tooltip title="Back to Previous Page">
-							<IconButton color="inherit" onClick={handleToPrevious}>
-								<ArrowBackIosNewIcon />
-							</IconButton>
-						</Tooltip>
+						{!editorState.shareRole && (
+							<Tooltip title="Back to Previous Page">
+								<IconButton color="inherit" onClick={handleToPrevious}>
+									<ArrowBackIosNewIcon />
+								</IconButton>
+							</Tooltip>
+						)}
 						<Paper>
 							{editorState.shareRole !== "READ" && (
 								<ToggleButtonGroup


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

**What this PR does / why we need it**:

This PR modifies the behavior and visibility of the 'Return to Workspace' button on the document page. Currently, clicking the button takes the user back to the previous page, which can lead to unintended navigation for external users. The button should take the user back to the workspace when clicked.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #142 

**Special notes for your reviewer**:

When accessed through sharing, there may not be a specific workspace to return to, so the 'Return to Workspace' button should not be displayed in such cases.

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```

**Additional documentation**:

<!--
This section can be blank if this pull request does not require a release note.

Please use the following format for linking documentation:
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```

**Checklist**:
- [x] Added relevant tests or not required
- [x] Didn't break anything
