### PR TITLE
Ensure Proper Cleanup of Yorkie Initialization Process

### DIFF
--- a/frontend/src/hooks/useYorkieDocument.ts
+++ b/frontend/src/hooks/useYorkieDocument.ts
@@ -10,7 +10,7 @@ import { selectAuth } from "../store/authSlice";
 yorkie.setLogLevel(4);
 
 export const useYorkieDocument = (
-	yorkieDocuentId?: string | null,
+	yorkieDocumentId?: string | null,
 	presenceName?: string | null
 ) => {
 	const [searchParams] = useSearchParams();
@@ -29,7 +29,7 @@ export const useYorkieDocument = (
 
 	useEffect(() => {
 		let mounted = true;
-		if (!yorkieDocuentId || !presenceName || doc || client) return;
+		if (!yorkieDocumentId || !presenceName || doc || client) return;
 
 		let yorkieToken = `default:${authStore.accessToken}`;
 
@@ -47,7 +47,7 @@ export const useYorkieDocument = (
 			const newDoc = new yorkie.Document<
 				YorkieCodeMirrorDocType,
 				YorkieCodeMirrorPresenceType
-			>(yorkieDocuentId);
+			>(yorkieDocumentId);
 
 			await newClient.attach(newDoc, {
 				initialPresence: {
@@ -72,7 +72,7 @@ export const useYorkieDocument = (
 		return () => {
 			mounted = false;
 		};
-	}, [presenceName, yorkieDocuentId, doc, client, authStore.accessToken, searchParams]);
+	}, [presenceName, yorkieDocumentId, doc, client, authStore.accessToken, searchParams]);
 
 	useEffect(() => {
 		return () => {

--- a/frontend/src/pages/workspace/document/Index.tsx
+++ b/frontend/src/pages/workspace/document/Index.tsx
@@ -16,10 +16,7 @@ function DocumentIndex() {
 	const userStore = useSelector(selectUser);
 	const { data: workspace } = useGetWorkspaceQuery(params.workspaceSlug);
 	const { data: document } = useGetDocumentQuery(workspace?.id, params.documentId);
-	const { doc, client, cleanUpYorkieDocument } = useYorkieDocument(
-		document?.yorkieDocumentId,
-		userStore.data?.nickname
-	);
+	const { doc, client } = useYorkieDocument(document?.yorkieDocumentId, userStore.data?.nickname);
 
 	useEffect(() => {
 		if (!doc || !client) return;
@@ -28,11 +25,10 @@ function DocumentIndex() {
 		dispatch(setClient(client));
 
 		return () => {
-			cleanUpYorkieDocument();
 			dispatch(setDoc(null));
 			dispatch(setClient(null));
 		};
-	}, [cleanUpYorkieDocument, dispatch, client, doc]);
+	}, [dispatch, client, doc]);
 
 	return (
 		<Box height="calc(100% - 64px)">

--- a/frontend/src/pages/workspace/document/share/Index.tsx
+++ b/frontend/src/pages/workspace/document/share/Index.tsx
@@ -13,10 +13,7 @@ function DocumentShareIndex() {
 	const [searchParams] = useSearchParams();
 	const shareToken = useMemo(() => searchParams.get("token"), [searchParams]);
 	const { data: sharedDocument } = useGetDocumentBySharingTokenQuery(shareToken);
-	const { doc, client, cleanUpYorkieDocument } = useYorkieDocument(
-		sharedDocument?.yorkieDocumentId,
-		"Anonymous"
-	);
+	const { doc, client } = useYorkieDocument(sharedDocument?.yorkieDocumentId, "Anonymous");
 
 	useEffect(() => {
 		if (!sharedDocument?.role) return;
@@ -35,11 +32,10 @@ function DocumentShareIndex() {
 		dispatch(setClient(client));
 
 		return () => {
-			cleanUpYorkieDocument();
 			dispatch(setDoc(null));
 			dispatch(setClient(null));
 		};
-	}, [cleanUpYorkieDocument, dispatch, client, doc]);
+	}, [dispatch, client, doc]);
 
 	if (!shareToken) return <Navigate to="/" state={{ from: location }} replace />;
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

**What this PR does / why we need it**:

This PR ensures that the Yorkie client and document are correctly detached and deactivated even if the component unmounts before the initialization finishes, preventing potential memory leaks and ensuring resource integrity.
- Added logic to handle cleanup of the Yorkie client if the component unmounts before initialization completes. (Ref: https://react.dev/learn/synchronizing-with-effects#fetching-data)
- Incorporated Yorkie cleanup within the `useYorkieDocument` hook to ensure comprehensive resource management.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #203 

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```

**Additional documentation**:

<!--
This section can be blank if this pull request does not require a release note.

Please use the following format for linking documentation:
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```

**Checklist**:
- [x] Added relevant tests or not required
- [x] Didn't break anything


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Renamed internal variables for consistency and clarity.
  - Improved resource cleanup by introducing a `mounted` flag.
  - Streamlined hook dependencies for better performance and maintainability.

- **Bug Fixes**
  - Corrected variable names to prevent potential issues related to typos.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->