### PR TITLE
Change `NODE_ENV` value to 'development' temporarily for enabling Devtools

### DIFF
--- a/frontend/.env.production
+++ b/frontend/.env.production
@@ -1,3 +1,4 @@
+NODE_ENV=development
 VITE_API_ADDR="https://codepair-api.yorkie.dev"
 VITE_YORKIE_API_ADDR="https://api.yorkie.dev"
 VITE_YORKIE_API_KEY="cbovg64qfu96agb5i0fg"


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

**What this PR does / why we need it**:
This PR temporarily changes the value of `NODE_ENV` from 'production' to 'development' to enable the Devtools for debugging purposes.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

**Special notes for your reviewer**:
In order to activate Devtools and facilitate debugging, it is necessary to set the environment to 'development' temporarily. This adjustment allows for better visibility and control during the debugging process.

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```

**Additional documentation**:

<!--
This section can be blank if this pull request does not require a release note.

Please use the following format for linking documentation:
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```

**Checklist**:
- [x] Added relevant tests or not required
- [x] Didn't break anything


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated environment configuration for production setup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->