### PR TITLE
Wrap `doc.update` to ensure `doc.update` code is executed only once

### DIFF
--- a/frontend/src/components/editor/YorkieIntelligenceFeature.tsx
+++ b/frontend/src/components/editor/YorkieIntelligenceFeature.tsx
@@ -122,18 +122,18 @@ function YorkieIntelligenceFeature(props: YorkieIntelligenceFeatureProps) {
 		const selectionFrom = replace ? from : from + 1;
 		const selectionTo = from + insert.length;
 
+		editorStore.doc?.update((root, presence) => {
+			root.content.edit(from, to, insert);
+			presence.set({
+				selection: root.content.indexRangeToPosRange([selectionFrom, selectionTo]),
+			});
+		});
 		editorStore.cmView?.dispatch({
 			changes: { from, to, insert },
 			selection: {
 				anchor: selectionFrom,
 				head: selectionTo,
 			},
-		});
-		editorStore.doc?.update((root, presence) => {
-			root.content.edit(from, to, insert);
-			presence.set({
-				selection: root.content.indexRangeToPosRange([selectionFrom, selectionTo]),
-			});
 		});
 		onClose();
 	};

--- a/frontend/src/utils/yorkie/yorkieSync.ts
+++ b/frontend/src/utils/yorkie/yorkieSync.ts
@@ -99,12 +99,12 @@ class YorkieSyncPluginValue implements cmView.PluginValue {
 					continue;
 				}
 				let adj = 0;
-				tr.changes.iterChanges((fromA, toA, _, __, inserted) => {
-					const insertText = inserted.toJSON().join("\n");
-					this._doc.update((root) => {
+				this._doc.update((root) => {
+					tr.changes.iterChanges((fromA, toA, _, __, inserted) => {
+						const insertText = inserted.toJSON().join("\n");
 						root.content.edit(fromA + adj, toA + adj, insertText);
+						adj += insertText.length - (toA - fromA);
 					});
-					adj += insertText.length - (toA - fromA);
 				});
 			}
 			const isSuccessful =
@@ -112,8 +112,8 @@ class YorkieSyncPluginValue implements cmView.PluginValue {
 
 			if (!isSuccessful) {
 				const errMessage = `YorkieSyncPlugin: Failed to sync the document
-				CM: ${this.view.state.doc.toString()}
-				Yorkie: ${this._doc.getRoot().content.toString()}`;
+CM: ${this.view.state.doc.toString()}
+Yorkie: ${this._doc.getRoot().content.toString()}`;
 
 				console.error(errMessage);
 				Sentry.captureMessage(errMessage);


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

**What this PR does / why we need it**:
This PR wraps `doc.update` to ensure that the `doc.update` code is executed only once, preventing multiple calls to `doc.update` based on the number of changes.

```typescript
tr.changes.iterChanges((fromA, toA, _, __, inserted) => {
  const insertText = inserted.toJSON().join("\n");

  // Wrapping doc.update to prevent multiple calls
  this._doc.update((root) => {
    root.content.edit(fromA + adj, toA + adj, insertText);
  });

  adj += insertText.length - (toA - fromA);
});
```

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```

**Additional documentation**:

<!--
This section can be blank if this pull request does not require a release note.

Please use the following format for linking documentation:
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```

**Checklist**:
- [x] Added relevant tests or not required
- [x] Didn't break anything


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Refactor**
  - Improved sequence of operations during content editing and selection setting to optimize editor performance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->