### PR TITLE
Change `GetDocument` API call to `GetDocuments` to prevent consecutive API calls

### DIFF
--- a/backend/src/workspace-documents/types/find-documents-from-yorkie-response.type.ts
+++ b/backend/src/workspace-documents/types/find-documents-from-yorkie-response.type.ts
@@ -7,6 +7,6 @@ class YorkieDocument {
 	accessedAt: string;
 }
 
-export class FindDocumentFromYorkieResponse {
-	document: YorkieDocument;
+export class FindDocumentsFromYorkieResponse {
+	documents: Array<YorkieDocument>;
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

**What this PR does / why we need it**:

This PR modifies the API call from `GetDocument` to `GetDocuments` to prevent consecutive API calls from occurring.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #173 

**Special notes for your reviewer**:

In this PR, the `GetDocuments` API call is implemented in place of the previous `GetDocument` call to prevent consecutive API calls and improve efficiency.

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```

**Additional documentation**:

https://github.com/yorkie-team/yorkie/pull/909

<!--
This section can be blank if this pull request does not require a release note.

Please use the following format for linking documentation:
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```

**Checklist**:
- [x] Added relevant tests or not required
- [x] Didn't break anything


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Enhanced document retrieval by allowing multiple documents to be fetched at once.

- **Refactor**
  - Renamed class and methods to support fetching multiple documents.
  - Updated internal logic to handle arrays of documents.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->