### PR TITLE
Fix loading issue of Document when viewing shared documents by moving `useSettingsQuery` Hook globally

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -21,6 +21,7 @@ import { QueryCache, QueryClient, QueryClientProvider } from "@tanstack/react-qu
 import AuthProvider from "./providers/AuthProvider";
 import { useErrorHandler } from "./hooks/useErrorHandler";
 import * as Sentry from "@sentry/react";
+import { useGetSettingsQuery } from "./hooks/api/settings";
 
 if (import.meta.env.PROD) {
 	Sentry.init({
@@ -48,6 +49,11 @@ if (import.meta.env.PROD) {
 const router = createBrowserRouter(routes);
 
 axios.defaults.baseURL = import.meta.env.VITE_API_ADDR;
+
+function SettingLoader() {
+	useGetSettingsQuery();
+	return null;
+}
 
 function App() {
 	const config = useSelector(selectConfig);
@@ -85,6 +91,7 @@ function App() {
 			<AuthProvider>
 				<ThemeProvider theme={theme}>
 					<CssBaseline />
+					<SettingLoader />
 					<Box minHeight="100vh">
 						<RouterProvider router={router} />
 					</Box>

--- a/frontend/src/components/common/PrivateRoute.tsx
+++ b/frontend/src/components/common/PrivateRoute.tsx
@@ -2,7 +2,6 @@ import { ReactNode, useContext } from "react";
 import { useLocation, Navigate } from "react-router-dom";
 import { AuthContext } from "../../contexts/AuthContext";
 import { Backdrop, CircularProgress } from "@mui/material";
-import { useGetSettingsQuery } from "../../hooks/api/settings";
 
 interface PrivateRouteProps {
 	children?: ReactNode;
@@ -12,8 +11,6 @@ const PrivateRoute = (props: PrivateRouteProps) => {
 	const { children } = props;
 	const { isLoggedIn, isLoading } = useContext(AuthContext);
 	const location = useLocation();
-
-	useGetSettingsQuery();
 
 	if (isLoading) {
 		return (


### PR DESCRIPTION
…equired pages causing Documents not to load

<!--  Thanks for sending a pull request! -->

**What this PR does / why we need it**:
This PR addresses the issue where the Document is not loading when viewing shared documents due to the `useSettingsQuery` Hook being active only on pages that require login. By moving the Hook globally and calling it on every page, the loading issue is resolved.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```

**Additional documentation**:

This bug is produced in https://github.com/yorkie-team/codepair/pull/231.

<!--
This section can be blank if this pull request does not require a release note.

Please use the following format for linking documentation:
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```

**Checklist**:
- [x] Added relevant tests or not required
- [x] Didn't break anything


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a `SettingLoader` component to streamline fetching and displaying settings within the app.

- **Refactor**
  - Removed redundant settings fetching from the `PrivateRoute` component to enhance performance and code organization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->