### PR TITLE
Add  Display additional users in a popover when there are more than 4 users

### DIFF
--- a/frontend/src/components/headers/DocumentHeader.tsx
+++ b/frontend/src/components/headers/DocumentHeader.tsx
@@ -11,7 +11,10 @@ import {
 	Tooltip,
 	Popover,
 	Typography,
-	Grid,
+	List,
+	ListItem,
+	ListItemAvatar,
+	ListItemText,
 } from "@mui/material";
 import EditIcon from "@mui/icons-material/Edit";
 import VerticalSplitIcon from "@mui/icons-material/VerticalSplit";
@@ -168,13 +171,11 @@ function DocumentHeader() {
 							}}
 						>
 							<Paper sx={{ padding: 2 }}>
-								<Typography variant="subtitle1" sx={{ marginBottom: 2 }}>
-									Additional Users
-								</Typography>
-								<Grid container spacing={2}>
+								<Typography variant="subtitle2">Additional Users</Typography>
+								<List>
 									{hiddenAvatars.map((presence) => (
-										<Grid item xs={4} key={presence.clientID}>
-											<Stack direction="row" alignItems="center" spacing={1}>
+										<ListItem key={presence.clientID} sx={{ paddingY: 0.5 }}>
+											<ListItemAvatar>
 												<Avatar
 													sx={{
 														bgcolor: presence.presence.color,
@@ -185,13 +186,16 @@ function DocumentHeader() {
 												>
 													{presence.presence.name[0]}
 												</Avatar>
-												<Typography variant="body2" sx={{ fontSize: 12 }}>
-													{presence.presence.name}
-												</Typography>
-											</Stack>
-										</Grid>
+											</ListItemAvatar>
+											<ListItemText
+												primary={presence.presence.name}
+												primaryTypographyProps={{
+													variant: "body2",
+												}}
+											/>
+										</ListItem>
 									))}
-								</Grid>
+								</List>
 							</Paper>
 						</Popover>
 						{!editorState.shareRole && <ShareButton />}

--- a/frontend/src/components/headers/DocumentHeader.tsx
+++ b/frontend/src/components/headers/DocumentHeader.tsx
@@ -9,6 +9,9 @@ import {
 	ToggleButtonGroup,
 	Toolbar,
 	Tooltip,
+	Popover,
+	Typography,
+	Grid,
 } from "@mui/material";
 import EditIcon from "@mui/icons-material/Edit";
 import VerticalSplitIcon from "@mui/icons-material/VerticalSplit";
@@ -17,7 +20,7 @@ import { useDispatch, useSelector } from "react-redux";
 import { EditorModeType, selectEditor, setMode } from "../../store/editorSlice";
 import ThemeButton from "../common/ThemeButton";
 import ShareButton from "../common/ShareButton";
-import { useEffect } from "react";
+import { useEffect, useState } from "react";
 import { useList } from "react-use";
 import { ActorID } from "yorkie-js-sdk";
 import { YorkieCodeMirrorPresenceType } from "../../utils/yorkie/yorkieSync";
@@ -43,6 +46,8 @@ function DocumentHeader() {
 		clientID: ActorID;
 		presence: YorkieCodeMirrorPresenceType;
 	}>([]);
+
+	const [anchorEl, setAnchorEl] = useState<HTMLElement | null>(null);
 
 	useEffect(() => {
 		if (editorState.shareRole === "READ") {
@@ -87,6 +92,20 @@ function DocumentHeader() {
 		navigate(`/${workspaceState.data?.slug}`);
 	};
 
+	// Display additional users in a popover when there are more than 4 users
+	const handleOpenPopover = (event: React.MouseEvent<HTMLElement>) => {
+		setAnchorEl(event.currentTarget);
+	};
+
+	// Display None additional users in a popover when there are more than 4 users
+	const handleClosePopover = () => {
+		setAnchorEl(null);
+	};
+
+	const popoverOpen = Boolean(anchorEl);
+
+	const hiddenAvatars = presenceList.slice(3);
+
 	return (
 		<AppBar position="static" sx={{ zIndex: 100 }}>
 			<Toolbar>
@@ -127,7 +146,7 @@ function DocumentHeader() {
 						</Paper>
 					</Stack>
 					<Stack direction="row" alignItems="center" gap={1}>
-						<AvatarGroup max={4}>
+						<AvatarGroup max={4} onClick={handleOpenPopover}>
 							{presenceList?.map((presence) => (
 								<Tooltip key={presence.clientID} title={presence.presence.name}>
 									<Avatar
@@ -139,6 +158,42 @@ function DocumentHeader() {
 								</Tooltip>
 							))}
 						</AvatarGroup>
+						<Popover
+							open={popoverOpen}
+							anchorEl={anchorEl}
+							onClose={handleClosePopover}
+							anchorOrigin={{
+								vertical: "bottom",
+								horizontal: "left",
+							}}
+						>
+							<Paper sx={{ padding: 2 }}>
+								<Typography variant="subtitle1" sx={{ marginBottom: 2 }}>
+									Additional Users
+								</Typography>
+								<Grid container spacing={2}>
+									{hiddenAvatars.map((presence) => (
+										<Grid item xs={4} key={presence.clientID}>
+											<Stack direction="row" alignItems="center" spacing={1}>
+												<Avatar
+													sx={{
+														bgcolor: presence.presence.color,
+														width: 24,
+														height: 24,
+														fontSize: 12,
+													}}
+												>
+													{presence.presence.name[0]}
+												</Avatar>
+												<Typography variant="body2" sx={{ fontSize: 12 }}>
+													{presence.presence.name}
+												</Typography>
+											</Stack>
+										</Grid>
+									))}
+								</Grid>
+							</Paper>
+						</Popover>
 						{!editorState.shareRole && <ShareButton />}
 						<ThemeButton />
 					</Stack>


### PR DESCRIPTION
#### What this PR does / why we need it?

This PR enhances the user experience by implementing a feature that displays additional users in a popover when there are more than 4 users displayed.

#### Any background context you want to provide?

Currently, when there are more than 4 users to be displayed, the UI becomes cluttered. To address this issue, this PR introduces a popover functionality that shows the remaining users when there are more than 4 present, providing a cleaner and more organized interface.

#### What are the relevant tickets?
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

### Checklist
- [x] Added relevant tests or not required
- [x] Didn't break anything

A bit more information would be helpful to complete the PR.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced a popover to display additional users when more than four are present, enhancing user interaction and interface clarity.
  
- **Improvements**
  - Enhanced the user presence visualization by integrating new elements from Material-UI, providing a cleaner and more informative experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->