### PR TITLE
Remove Global Scroll on Document Edit Page

### DIFF
--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -1,7 +1,7 @@
 body {
 	margin: 0;
 	min-height: 100vh;
-    overflow: hidden;
+	overflow: hidden;
 }
 
 #yorkie-intelligence-footer .wmde-markdown {

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -1,6 +1,7 @@
 body {
 	margin: 0;
 	min-height: 100vh;
+    overflow: hidden;
 }
 
 #yorkie-intelligence-footer .wmde-markdown {


### PR DESCRIPTION
**What this PR does / why we need it**:

This pull request to prevent users from experiencing global scrolling with bottom whitespace, which was intermittently caused by differences in the height of markdown syntax, such as latex, and the posts written in it.

**Which issue(s) this PR fixes**:

Fixes #201

**Special notes for your reviewer**:
encountered an issue when editorStore.mode was set to edit or both. We initially attempted to resolve the problem by removing the height: "100%" value from the Box component in each mode. While this approach worked for the edit mode, it caused an issue in the "both mode" where individual block scrolling was lost. To address this, we added ```overflow: hidden``` to the body of the top-level html element, which resolved the issue and ensured that it worked correctly in other scenarios as well.

If you have any suggestions for a better solution or notice any issues with this approach, we would greatly appreciate your feedback.

**Does this PR introduce a user-facing change?**:

With overflow:hidden, we wanted to prevent users from experiencing global scrolling with bottom whitespace, which was intermittently caused by differences in the height of markdown syntax, such as latex, and the posts written in it.

**Checklist**:
- [x] Added relevant tests or not required
- [x] Didn't break anything

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **Style**
	- Updated the body element's overflow behavior to enhance layout control by preventing content overflow visibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->