### PR TITLE
Add Korean font to Docker image for language rendering in Markdown Export using Puppeteer

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -51,6 +51,12 @@ RUN apk add --no-cache \
     ca-certificates \
     ttf-freefont
 
+# Download Korean font for Puppeteer
+RUN mkdir /usr/share/fonts/nanumfont && \
+    wget http://cdn.naver.com/naver/NanumFont/fontfiles/NanumFont_TTF_ALL.zip && \
+    unzip NanumFont_TTF_ALL.zip -d /usr/share/fonts/nanumfont && \ 
+    fc-cache -f -v
+
 # Set the environment variables
 ENV NODE_ENV production
 ENV PUPPETEER_SKIP_CHROMIUM_DOWNLOAD true


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

**What this PR does / why we need it**:
This PR adds a Korean font to the Docker image to enable proper language rendering when using the Markdown Export feature with Puppeteer.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

**Special notes for your reviewer**:
The use of Puppeteer for Markdown Export requires specific fonts to render languages correctly. By adding a Korean font to the Docker image, we ensure that Korean language characters are displayed accurately in the exported Markdown files.

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```

**Additional documentation**:

<!--
This section can be blank if this pull request does not require a release note.

Please use the following format for linking documentation:
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```

**Checklist**:
- [x] Added relevant tests or not required
- [x] Didn't break anything
