### PR TITLE
Fix Checking Conflict in Note Creation

### DIFF
--- a/backend/src/workspaces/workspaces.controller.ts
+++ b/backend/src/workspaces/workspaces.controller.ts
@@ -68,7 +68,6 @@ export class WorkspacesController {
 		@Req() req: AuthroizedRequest,
 		@Param("workspace_slug") workspaceSlug: string
 	): Promise<FindWorkspaceResponse> {
-		console.log(encodeURI(workspaceSlug));
 		return this.workspacesService.findOneBySlug(req.user.id, encodeURI(workspaceSlug));
 	}
 

--- a/frontend/src/components/modals/CreateModal.tsx
+++ b/frontend/src/components/modals/CreateModal.tsx
@@ -31,6 +31,8 @@ function CreateModal(props: CreateModalProps) {
 	const { data: conflictResult } = useCheckNameConflictQuery(debouncedNickname);
 
 	const errorMessage = useMemo(() => {
+		if (!enableConflictCheck) return null;
+
 		if (nickname.length < 2) {
 			return "Title must be at least 2 characters";
 		}
@@ -38,7 +40,7 @@ function CreateModal(props: CreateModalProps) {
 			return "Already Exists";
 		}
 		return null;
-	}, [nickname.length, conflictResult?.conflict]);
+	}, [enableConflictCheck, nickname.length, conflictResult?.conflict]);
 
 	useDebounce(
 		() => {


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

**What this PR does / why we need it**:

When creating note, there's no need to enable name conflict.
However, the `errorMessage` exists in creating note.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```

**Additional documentation**:

<!--
This section can be blank if this pull request does not require a release note.

Please use the following format for linking documentation:
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```

**Checklist**:
- [x] Added relevant tests or not required
- [x] Didn't break anything


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Improved error message logic in the CreateModal component, enhancing responsiveness based on the conflict check setting.
- **Bug Fixes**
	- Removed unnecessary console logging in the WorkspacesController, improving code cleanliness without affecting functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->