### PR TITLE
Remove unnecessary package-lock.json file

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,0 @@
-{
-  "name": "codepair",
-  "lockfileVersion": 3,
-  "requires": true,
-  "packages": {}
-}


### PR DESCRIPTION
#### What this PR does / why we need it?
This PR removes the unnecessary package-lock.json file located outside the frontend and backend folders.

#### Any background context you want to provide?
The package-lock.json file was mistakenly placed in a location outside of the designated folders. This file is not required in that location and has been removed to maintain a clean project structure.

#### What are the relevant tickets?
No specific issue linked.

### Checklist
- [ ] Added relevant tests or not required
- [x] Didn't break anything