### PR TITLE
Fix Slidebar Overlapping

### DIFF
--- a/frontend/src/components/drawers/WorkspaceDrawer.tsx
+++ b/frontend/src/components/drawers/WorkspaceDrawer.tsx
@@ -63,7 +63,7 @@ function WorkspaceDrawer(props: WorkspaceDrawerProps) {
 	};
 
 	return (
-		<>
+		<Box>
 			<Box sx={{ width: open ? DRAWER_WIDTH : COLLAPESED_DRAWER_WIDTH }} />
 			<Paper
 				sx={{
@@ -122,7 +122,7 @@ function WorkspaceDrawer(props: WorkspaceDrawerProps) {
 					</Box>
 				</Collapse>
 			</Paper>
-		</>
+		</Box>
 	);
 }
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

**What this PR does / why we need it**:

<img width="2056" alt="image" src="https://github.com/user-attachments/assets/1d471ba4-e26c-4388-9181-af62a64efa9a">

When there's more than 14 documents, slidebar overlaps the document cards.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```

**Additional documentation**:

<!--
This section can be blank if this pull request does not require a release note.

Please use the following format for linking documentation:
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```

**Checklist**:
- [x] Added relevant tests or not required
- [x] Didn't break anything


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Enhancements**
	- Updated the `WorkspaceDrawer` component to improve structure and layout by replacing the fragment with a `<Box>` component, potentially enhancing styling and rendering behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->