### PR TITLE
Add scroll navigation to user's location from profile view

### DIFF
--- a/frontend/src/components/editor/Editor.tsx
+++ b/frontend/src/components/editor/Editor.tsx
@@ -1,21 +1,20 @@
-import { useCallback, useEffect, useState } from "react";
-import { EditorState } from "@codemirror/state";
-import { EditorView, basicSetup } from "codemirror";
 import { markdown } from "@codemirror/lang-markdown";
-import { useDispatch, useSelector } from "react-redux";
-import { selectEditor, setCmView } from "../../store/editorSlice";
-import { yorkieCodeMirror } from "../../utils/yorkie";
-import { xcodeLight, xcodeDark } from "@uiw/codemirror-theme-xcode";
-import { useCurrentTheme } from "../../hooks/useCurrentTheme";
+import { EditorState } from "@codemirror/state";
 import { keymap, ViewUpdate } from "@codemirror/view";
-import { intelligencePivot } from "../../utils/intelligence/intelligencePivot";
-import { imageUploader } from "../../utils/imageUploader";
-import { useCreateUploadUrlMutation, useUploadFileMutation } from "../../hooks/api/file";
-import { selectWorkspace } from "../../store/workspaceSlice";
+import { xcodeDark, xcodeLight } from "@uiw/codemirror-theme-xcode";
+import { basicSetup, EditorView } from "codemirror";
+import { useCallback, useEffect, useState } from "react";
+import { useDispatch, useSelector } from "react-redux";
 import { ScrollSyncPane } from "react-scroll-sync";
+import { useCreateUploadUrlMutation, useUploadFileMutation } from "../../hooks/api/file";
+import { useCurrentTheme } from "../../hooks/useCurrentTheme";
+import { FormatType, ToolBarState, useFormatUtils } from "../../hooks/useFormatUtils";
+import { selectEditor, setCmView } from "../../store/editorSlice";
 import { selectSetting } from "../../store/settingSlice";
-import { ToolBarState, useFormatUtils, FormatType } from "../../hooks/useFormatUtils";
-
+import { selectWorkspace } from "../../store/workspaceSlice";
+import { imageUploader } from "../../utils/imageUploader";
+import { intelligencePivot } from "../../utils/intelligence/intelligencePivot";
+import { yorkieCodeMirror } from "../../utils/yorkie";
 import ToolBar from "./ToolBar";
 
 function Editor() {

--- a/frontend/src/components/headers/DocumentHeader.tsx
+++ b/frontend/src/components/headers/DocumentHeader.tsx
@@ -23,7 +23,7 @@ import { YorkieCodeMirrorPresenceType } from "../../utils/yorkie/yorkieSync";
 import DownloadMenu from "../common/DownloadMenu";
 import ShareButton from "../common/ShareButton";
 import ThemeButton from "../common/ThemeButton";
-import UserPresence from "./UserPresence";
+import UserPresenceList from "./UserPresenceList";
 
 export type Presence = {
 	clientID: ActorID;
@@ -130,7 +130,7 @@ function DocumentHeader() {
 						<DownloadMenu />
 					</Stack>
 					<Stack direction="row" alignItems="center" gap={1}>
-						<UserPresence presenceList={presenceList} />
+						<UserPresenceList presenceList={presenceList} />
 						{!editorState.shareRole && <ShareButton />}
 						<ThemeButton />
 					</Stack>

--- a/frontend/src/components/headers/DocumentHeader.tsx
+++ b/frontend/src/components/headers/DocumentHeader.tsx
@@ -15,70 +15,26 @@ import {
 import { useEffect } from "react";
 import { useDispatch, useSelector } from "react-redux";
 import { useNavigate } from "react-router-dom";
-import { useList } from "react-use";
-import { ActorID } from "yorkie-js-sdk";
+import { useUserPresence } from "../../hooks/useUserPresence";
 import { EditorModeType, selectEditor, setMode } from "../../store/editorSlice";
 import { selectWorkspace } from "../../store/workspaceSlice";
-import { YorkieCodeMirrorPresenceType } from "../../utils/yorkie/yorkieSync";
 import DownloadMenu from "../common/DownloadMenu";
 import ShareButton from "../common/ShareButton";
 import ThemeButton from "../common/ThemeButton";
 import UserPresenceList from "./UserPresenceList";
-
-export type Presence = {
-	clientID: ActorID;
-	presence: YorkieCodeMirrorPresenceType;
-};
 
 function DocumentHeader() {
 	const dispatch = useDispatch();
 	const navigate = useNavigate();
 	const editorState = useSelector(selectEditor);
 	const workspaceState = useSelector(selectWorkspace);
-	const [
-		presenceList,
-		{
-			set: setPresenceList,
-			push: pushToPresenceList,
-			removeAt: removePresenceAt,
-			clear: clearPresenceList,
-			filter: filterPresenceList,
-		},
-	] = useList<Presence>([]);
+	const { presenceList } = useUserPresence(editorState.doc);
 
 	useEffect(() => {
 		if (editorState.shareRole === "READ") {
 			dispatch(setMode("read"));
 		}
 	}, [dispatch, editorState.shareRole]);
-
-	useEffect(() => {
-		if (!editorState.doc) return;
-
-		setPresenceList(editorState.doc.getPresences());
-
-		const unsubscribe = editorState.doc.subscribe("others", (event) => {
-			if (event.type === "watched") {
-				setPresenceList(editorState.doc?.getPresences?.() ?? []);
-			}
-
-			if (event.type === "unwatched") {
-				filterPresenceList((presence) => presence.clientID !== event.value.clientID);
-			}
-		});
-
-		return () => {
-			unsubscribe();
-			clearPresenceList();
-		};
-	}, [
-		editorState.doc,
-		clearPresenceList,
-		pushToPresenceList,
-		removePresenceAt,
-		setPresenceList,
-		filterPresenceList,
-	]);
 
 	const handleChangeMode = (newMode: EditorModeType) => {
 		if (!newMode) return;

--- a/frontend/src/components/headers/DocumentHeader.tsx
+++ b/frontend/src/components/headers/DocumentHeader.tsx
@@ -4,6 +4,7 @@ import VerticalSplitIcon from "@mui/icons-material/VerticalSplit";
 import VisibilityIcon from "@mui/icons-material/Visibility";
 import {
 	AppBar,
+	CircularProgress,
 	IconButton,
 	Paper,
 	Stack,
@@ -12,7 +13,7 @@ import {
 	Toolbar,
 	Tooltip,
 } from "@mui/material";
-import { useEffect } from "react";
+import { lazy, Suspense, useEffect } from "react";
 import { useDispatch, useSelector } from "react-redux";
 import { useNavigate } from "react-router-dom";
 import { useUserPresence } from "../../hooks/useUserPresence";
@@ -21,8 +22,8 @@ import { selectWorkspace } from "../../store/workspaceSlice";
 import DownloadMenu from "../common/DownloadMenu";
 import ShareButton from "../common/ShareButton";
 import ThemeButton from "../common/ThemeButton";
-import UserPresenceList from "./UserPresenceList";
 
+const UserPresenceList = lazy(() => import("./UserPresenceList"));
 function DocumentHeader() {
 	const dispatch = useDispatch();
 	const navigate = useNavigate();
@@ -86,7 +87,9 @@ function DocumentHeader() {
 						<DownloadMenu />
 					</Stack>
 					<Stack direction="row" alignItems="center" gap={1}>
-						<UserPresenceList presenceList={presenceList} />
+						<Suspense fallback={<CircularProgress size={24} />}>
+							<UserPresenceList presenceList={presenceList} />
+						</Suspense>
 						{!editorState.shareRole && <ShareButton />}
 						<ThemeButton />
 					</Stack>

--- a/frontend/src/components/headers/DocumentHeader.tsx
+++ b/frontend/src/components/headers/DocumentHeader.tsx
@@ -4,7 +4,6 @@ import VerticalSplitIcon from "@mui/icons-material/VerticalSplit";
 import VisibilityIcon from "@mui/icons-material/Visibility";
 import {
 	AppBar,
-	CircularProgress,
 	IconButton,
 	Paper,
 	Stack,
@@ -13,7 +12,7 @@ import {
 	Toolbar,
 	Tooltip,
 } from "@mui/material";
-import { lazy, Suspense, useEffect } from "react";
+import { useEffect } from "react";
 import { useDispatch, useSelector } from "react-redux";
 import { useNavigate } from "react-router-dom";
 import { useUserPresence } from "../../hooks/useUserPresence";
@@ -22,8 +21,8 @@ import { selectWorkspace } from "../../store/workspaceSlice";
 import DownloadMenu from "../common/DownloadMenu";
 import ShareButton from "../common/ShareButton";
 import ThemeButton from "../common/ThemeButton";
+import UserPresenceList from "./UserPresenceList";
 
-const UserPresenceList = lazy(() => import("./UserPresenceList"));
 function DocumentHeader() {
 	const dispatch = useDispatch();
 	const navigate = useNavigate();
@@ -87,9 +86,7 @@ function DocumentHeader() {
 						<DownloadMenu />
 					</Stack>
 					<Stack direction="row" alignItems="center" gap={1}>
-						<Suspense fallback={<CircularProgress size={24} />}>
-							<UserPresenceList presenceList={presenceList} />
-						</Suspense>
+						<UserPresenceList presenceList={presenceList} />
 						{!editorState.shareRole && <ShareButton />}
 						<ThemeButton />
 					</Stack>

--- a/frontend/src/components/headers/UserPresenceList.tsx
+++ b/frontend/src/components/headers/UserPresenceList.tsx
@@ -10,7 +10,7 @@ import {
 	Typography,
 } from "@mui/material";
 import { useState } from "react";
-import { Presence } from "./DocumentHeader";
+import { Presence } from "../../hooks/useUserPresence";
 
 interface UserPresenceListProps {
 	presenceList: Presence[];
@@ -35,7 +35,7 @@ function UserPresenceList(props: UserPresenceListProps) {
 	const renderAvatar = (presence: Presence) => (
 		<Tooltip key={presence.clientID} title={presence.presence.name}>
 			<Avatar
-				onClick={() => console.log(presence.presence)}
+				onClick={() => console.log("presence: ", presence)}
 				alt={presence.presence.name}
 				sx={{ bgcolor: presence.presence.color }}
 			>

--- a/frontend/src/components/headers/UserPresenceList.tsx
+++ b/frontend/src/components/headers/UserPresenceList.tsx
@@ -9,8 +9,11 @@ import {
 	Tooltip,
 	Typography,
 } from "@mui/material";
+import { EditorView } from "codemirror";
 import { useState } from "react";
+import { useSelector } from "react-redux";
 import { Presence } from "../../hooks/useUserPresence";
+import { selectEditor } from "../../store/editorSlice";
 
 interface UserPresenceListProps {
 	presenceList: Presence[];
@@ -20,6 +23,7 @@ function UserPresenceList(props: UserPresenceListProps) {
 	const { presenceList } = props;
 	const [anchorEl, setAnchorEl] = useState<HTMLElement | null>(null);
 	const popoverOpen = Boolean(anchorEl);
+	const editorStore = useSelector(selectEditor);
 
 	const handleOpenPopover = (event: React.MouseEvent<HTMLElement>) => {
 		setAnchorEl(event.currentTarget);
@@ -29,13 +33,22 @@ function UserPresenceList(props: UserPresenceListProps) {
 		setAnchorEl(null);
 	};
 
+	const handleScrollToUserLocation = (presence: Presence) => {
+		const cursor = presence.presence.cursor;
+		editorStore.cmView?.dispatch({
+			effects: EditorView.scrollIntoView(cursor[0], {
+				y: "center",
+			}),
+		});
+	};
+
 	const MAX_VISIBLE_AVATARS = 4;
 	const hiddenAvatars = presenceList.slice(MAX_VISIBLE_AVATARS);
 
 	const renderAvatar = (presence: Presence) => (
 		<Tooltip key={presence.clientID} title={presence.presence.name}>
 			<Avatar
-				onClick={() => console.log("presence: ", presence)}
+				onClick={() => handleScrollToUserLocation(presence)}
 				alt={presence.presence.name}
 				sx={{ bgcolor: presence.presence.color }}
 			>
@@ -66,7 +79,11 @@ function UserPresenceList(props: UserPresenceListProps) {
 				<Paper sx={{ padding: 2 }}>
 					<Typography variant="subtitle2">Additional Users</Typography>
 					{hiddenAvatars.map((presence) => (
-						<ListItem key={presence.clientID} sx={{ paddingY: 1 }}>
+						<ListItem
+							key={presence.clientID}
+							sx={{ paddingY: 1 }}
+							onClick={() => handleScrollToUserLocation(presence)}
+						>
 							<ListItemAvatar>
 								<Avatar
 									sx={{

--- a/frontend/src/components/headers/UserPresenceList.tsx
+++ b/frontend/src/components/headers/UserPresenceList.tsx
@@ -35,6 +35,8 @@ function UserPresenceList(props: UserPresenceListProps) {
 
 	const handleScrollToUserLocation = (presence: Presence) => {
 		const cursor = presence.presence.cursor;
+		if (cursor === null) return;
+
 		editorStore.cmView?.dispatch({
 			effects: EditorView.scrollIntoView(cursor[0], {
 				y: "center",

--- a/frontend/src/components/headers/UserPresenceList.tsx
+++ b/frontend/src/components/headers/UserPresenceList.tsx
@@ -12,11 +12,11 @@ import {
 import { useState } from "react";
 import { Presence } from "./DocumentHeader";
 
-interface UserPresenceProps {
+interface UserPresenceListProps {
 	presenceList: Presence[];
 }
 
-function UserPresence(props: UserPresenceProps) {
+function UserPresenceList(props: UserPresenceListProps) {
 	const { presenceList } = props;
 	const [anchorEl, setAnchorEl] = useState<HTMLElement | null>(null);
 	const popoverOpen = Boolean(anchorEl);
@@ -34,7 +34,11 @@ function UserPresence(props: UserPresenceProps) {
 
 	const renderAvatar = (presence: Presence) => (
 		<Tooltip key={presence.clientID} title={presence.presence.name}>
-			<Avatar alt={presence.presence.name} sx={{ bgcolor: presence.presence.color }}>
+			<Avatar
+				onClick={() => console.log(presence.presence)}
+				alt={presence.presence.name}
+				sx={{ bgcolor: presence.presence.color }}
+			>
 				{presence.presence.name[0]}
 			</Avatar>
 		</Tooltip>
@@ -89,4 +93,4 @@ function UserPresence(props: UserPresenceProps) {
 	);
 }
 
-export default UserPresence;
+export default UserPresenceList;

--- a/frontend/src/hooks/useUserPresence.ts
+++ b/frontend/src/hooks/useUserPresence.ts
@@ -1,5 +1,4 @@
-import { useEffect } from "react";
-import { useList } from "react-use";
+import { useEffect, useState } from "react";
 import { ActorID } from "yorkie-js-sdk";
 import { CodePairDocType } from "../store/editorSlice";
 import { YorkieCodeMirrorPresenceType } from "../utils/yorkie/yorkieSync";
@@ -10,35 +9,32 @@ export type Presence = {
 };
 
 export const useUserPresence = (doc: CodePairDocType | null) => {
-	const [
-		presenceList,
-		{ set: setPresenceList, clear: clearPresenceList, filter: filterPresenceList },
-	] = useList<Presence>([]);
+	const [presenceList, setPresenceList] = useState<Presence[]>([]);
 
 	useEffect(() => {
 		if (!doc) return;
 
-		setPresenceList(doc.getPresences());
+		const updatePresences = () => setPresenceList(doc.getPresences() ?? []);
+
+		updatePresences();
 
 		const unsubscribe = doc.subscribe("others", (event) => {
-			if (event.type === "presence-changed") {
-				setPresenceList(doc.getPresences() ?? []);
-			}
-
-			if (event.type === "watched") {
-				setPresenceList(doc.getPresences() ?? []);
+			if (event.type === "presence-changed" || event.type === "watched") {
+				updatePresences();
 			}
 
 			if (event.type === "unwatched") {
-				filterPresenceList((presence) => presence.clientID !== event.value.clientID);
+				setPresenceList((prev) =>
+					prev.filter((presence) => presence.clientID !== event.value.clientID)
+				);
 			}
 		});
 
 		return () => {
 			unsubscribe();
-			clearPresenceList();
+			setPresenceList([]);
 		};
-	}, [doc, clearPresenceList, setPresenceList, filterPresenceList]);
+	}, [doc]);
 
 	return { presenceList };
 };

--- a/frontend/src/hooks/useUserPresence.ts
+++ b/frontend/src/hooks/useUserPresence.ts
@@ -1,0 +1,40 @@
+import { useEffect } from "react";
+import { useList } from "react-use";
+import { ActorID } from "yorkie-js-sdk";
+import { CodePairDocType } from "../store/editorSlice";
+import { YorkieCodeMirrorPresenceType } from "../utils/yorkie/yorkieSync";
+
+export type Presence = {
+	clientID: ActorID;
+	presence: YorkieCodeMirrorPresenceType;
+};
+
+export const useUserPresence = (doc: CodePairDocType | null) => {
+	const [
+		presenceList,
+		{ set: setPresenceList, clear: clearPresenceList, filter: filterPresenceList },
+	] = useList<Presence>([]);
+
+	useEffect(() => {
+		if (!doc) return;
+
+		setPresenceList(doc.getPresences());
+
+		const unsubscribe = doc.subscribe("others", (event) => {
+			if (event.type === "watched") {
+				setPresenceList(doc.getPresences() ?? []);
+			}
+
+			if (event.type === "unwatched") {
+				filterPresenceList((presence) => presence.clientID !== event.value.clientID);
+			}
+		});
+
+		return () => {
+			unsubscribe();
+			clearPresenceList();
+		};
+	}, [doc, clearPresenceList, setPresenceList, filterPresenceList]);
+
+	return { presenceList };
+};

--- a/frontend/src/hooks/useUserPresence.ts
+++ b/frontend/src/hooks/useUserPresence.ts
@@ -21,6 +21,10 @@ export const useUserPresence = (doc: CodePairDocType | null) => {
 		setPresenceList(doc.getPresences());
 
 		const unsubscribe = doc.subscribe("others", (event) => {
+			if (event.type === "presence-changed") {
+				setPresenceList(doc.getPresences() ?? []);
+			}
+
 			if (event.type === "watched") {
 				setPresenceList(doc.getPresences() ?? []);
 			}

--- a/frontend/src/hooks/useYorkieDocument.ts
+++ b/frontend/src/hooks/useYorkieDocument.ts
@@ -47,7 +47,7 @@ export const useYorkieDocument = (
 					name: presenceName,
 					color: Color(randomColor()).fade(0.15).toString(),
 					selection: null,
-					cursor: [0, 0],
+					cursor: null,
 				},
 			});
 		},

--- a/frontend/src/hooks/useYorkieDocument.ts
+++ b/frontend/src/hooks/useYorkieDocument.ts
@@ -47,6 +47,7 @@ export const useYorkieDocument = (
 					name: presenceName,
 					color: Color(randomColor()).fade(0.15).toString(),
 					selection: null,
+					cursor: [0, 0],
 				},
 			});
 		},

--- a/frontend/src/hooks/useYorkieDocument.ts
+++ b/frontend/src/hooks/useYorkieDocument.ts
@@ -1,11 +1,15 @@
-import { useCallback, useEffect, useState } from "react";
-import * as yorkie from "yorkie-js-sdk";
-import { YorkieCodeMirrorDocType, YorkieCodeMirrorPresenceType } from "../utils/yorkie/yorkieSync";
 import Color from "color";
 import randomColor from "randomcolor";
-import { useSearchParams } from "react-router-dom";
+import { useCallback, useEffect, useState } from "react";
 import { useSelector } from "react-redux";
+import { useSearchParams } from "react-router-dom";
+import * as yorkie from "yorkie-js-sdk";
 import { selectAuth } from "../store/authSlice";
+import { CodePairDocType } from "../store/editorSlice";
+import { YorkieCodeMirrorDocType, YorkieCodeMirrorPresenceType } from "../utils/yorkie/yorkieSync";
+
+const YORKIE_API_ADDR = import.meta.env.VITE_YORKIE_API_ADDR;
+const YORKIE_API_KEY = import.meta.env.VITE_YORKIE_API_KEY;
 
 yorkie.setLogLevel(4);
 
@@ -16,65 +20,92 @@ export const useYorkieDocument = (
 	const [searchParams] = useSearchParams();
 	const authStore = useSelector(selectAuth);
 	const [client, setClient] = useState<yorkie.Client | null>(null);
-	const [doc, setDoc] = useState<yorkie.Document<
-		YorkieCodeMirrorDocType,
-		YorkieCodeMirrorPresenceType
-	> | null>(null);
-	const cleanUpYorkieDocument = useCallback(async () => {
-		if (!client || !doc) return;
+	const [doc, setDoc] = useState<CodePairDocType | null>(null);
 
-		await client?.detach(doc);
-		await client?.deactivate();
-	}, [client, doc]);
+	const getYorkieToken = useCallback(() => {
+		const shareToken = searchParams.get("token");
+		return shareToken ? `share:${shareToken}` : `default:${authStore.accessToken}`;
+	}, [authStore.accessToken, searchParams]);
 
-	useEffect(() => {
-		let mounted = true;
-		if (!yorkieDocumentId || !presenceName || doc || client) return;
+	const createYorkieClient = useCallback(async (yorkieToken: string) => {
+		const newClient = new yorkie.Client(YORKIE_API_ADDR, {
+			apiKey: YORKIE_API_KEY,
+			token: yorkieToken,
+		});
+		await newClient.activate();
+		return newClient;
+	}, []);
 
-		let yorkieToken = `default:${authStore.accessToken}`;
-
-		if (searchParams.get("token")) {
-			yorkieToken = `share:${searchParams.get("token")}`;
-		}
-
-		const initializeYorkie = async () => {
-			const newClient = new yorkie.Client(import.meta.env.VITE_YORKIE_API_ADDR, {
-				apiKey: import.meta.env.VITE_YORKIE_API_KEY,
-				token: yorkieToken,
-			});
-			await newClient.activate();
-
-			const newDoc = new yorkie.Document<
+	const createYorkieDocument = useCallback(
+		(client: yorkie.Client, yorkieDocumentId: string, presenceName: string) => {
+			const newDocument = new yorkie.Document<
 				YorkieCodeMirrorDocType,
 				YorkieCodeMirrorPresenceType
-			>(yorkieDocumentId, {
-				enableDevtools: true,
-			});
-
-			await newClient.attach(newDoc, {
+			>(yorkieDocumentId, { enableDevtools: true });
+			return client.attach(newDocument, {
 				initialPresence: {
 					name: presenceName,
 					color: Color(randomColor()).fade(0.15).toString(),
 					selection: null,
 				},
 			});
+		},
+		[]
+	);
 
-			// Clean up if the component is unmounted before the initialization is done
-			if (!mounted) {
-				await newClient.detach(newDoc);
-				await newClient.deactivate();
-				return;
+	const cleanUpYorkieDocument = useCallback(async () => {
+		if (!client || !doc) return;
+
+		try {
+			await client.detach(doc);
+			await client.deactivate();
+		} catch (error) {
+			console.error("Error during Yorkie cleanup:", error);
+		}
+	}, [client, doc]);
+
+	useEffect(() => {
+		let mounted = true;
+		if (!yorkieDocumentId || !presenceName || doc || client) return;
+
+		const initializeYorkie = async () => {
+			try {
+				const yorkieToken = getYorkieToken();
+				const newClient = await createYorkieClient(yorkieToken);
+				const newDoc = await createYorkieDocument(
+					newClient,
+					yorkieDocumentId,
+					presenceName
+				);
+
+				// Clean up if the component is unmounted before the initialization is done
+				if (!mounted) {
+					await newClient.detach(newDoc);
+					await newClient.deactivate();
+					return;
+				}
+
+				setClient(newClient);
+				setDoc(newDoc);
+			} catch (error) {
+				console.error("Error initializing Yorkie: ", error);
 			}
-
-			setClient(newClient);
-			setDoc(newDoc);
 		};
+
 		initializeYorkie();
 
 		return () => {
 			mounted = false;
 		};
-	}, [presenceName, yorkieDocumentId, doc, client, authStore.accessToken, searchParams]);
+	}, [
+		presenceName,
+		yorkieDocumentId,
+		doc,
+		client,
+		getYorkieToken,
+		createYorkieClient,
+		createYorkieDocument,
+	]);
 
 	useEffect(() => {
 		return () => {

--- a/frontend/src/routes.tsx
+++ b/frontend/src/routes.tsx
@@ -3,17 +3,17 @@ import GuestRoute from "./components/common/GuestRoute";
 import PrivateRoute from "./components/common/PrivateRoute";
 import DocumentLayout from "./components/layouts/DocumentLayout";
 import MainLayout from "./components/layouts/MainLayout";
+import SettingLayout from "./components/layouts/SettingLayout";
 import WorkspaceLayout from "./components/layouts/WorkspaceLayout";
 import Index from "./pages/Index";
 import CallbackIndex from "./pages/auth/callback/Index";
+import NotFound from "./pages/error";
+import ProfileIndex from "./pages/settings/profile/Index";
 import WorkspaceIndex from "./pages/workspace/Index";
 import DocumentIndex from "./pages/workspace/document/Index";
 import DocumentShareIndex from "./pages/workspace/document/share/Index";
 import JoinIndex from "./pages/workspace/join/Index";
 import MemberIndex from "./pages/workspace/member/Index";
-import NotFound from "./pages/error";
-import ProfileIndex from "./pages/settings/profile/Index";
-import SettingLayout from "./components/layouts/SettingLayout";
 
 interface CodePairRoute {
 	path: string;
@@ -29,7 +29,7 @@ interface CodePairRoute {
 
 const enum AccessType {
 	PUBLIC, // Everyone can access (Default)
-	PRIVATE, // Authroized user can access only
+	PRIVATE, // Authorized user can access only
 	GUEST, // Not authorized user can access only
 }
 

--- a/frontend/src/utils/yorkie/remoteSelection.ts
+++ b/frontend/src/utils/yorkie/remoteSelection.ts
@@ -1,17 +1,15 @@
-import * as cmView from "@codemirror/view";
-
 import * as cmState from "@codemirror/state";
+import * as cmView from "@codemirror/view";
 import * as dom from "lib0/dom";
 import * as pair from "lib0/pair";
+import _ from "lodash";
 import * as yorkie from "yorkie-js-sdk";
-
 import {
-	YorkieSyncConfig,
 	YorkieCodeMirrorDocType,
 	YorkieCodeMirrorPresenceType,
+	YorkieSyncConfig,
 	yorkieSyncFacet,
 } from "./yorkieSync.js";
-import _ from "lodash";
 
 export const yorkieRemoteSelectionsTheme = cmView.EditorView.baseTheme({
 	".cm-ySelection": {},
@@ -162,6 +160,7 @@ export class YorkieRemoteSelectionsPluginValue {
 			} else if (presence.get("selection")) {
 				presence.set({
 					selection: null,
+					cursor: null,
 				});
 			}
 		});

--- a/frontend/src/utils/yorkie/remoteSelection.ts
+++ b/frontend/src/utils/yorkie/remoteSelection.ts
@@ -151,10 +151,12 @@ export class YorkieRemoteSelectionsPluginValue {
 
 			if (sel && root.content) {
 				const selection = root.content.indexRangeToPosRange([sel.anchor, sel.head]);
+				const cursor = root.content.posRangeToIndexRange(selection);
 
 				if (!_.isEqual(selection, presence.get("selection"))) {
 					presence.set({
 						selection,
+						cursor,
 					});
 				}
 			} else if (presence.get("selection")) {

--- a/frontend/src/utils/yorkie/yorkieSync.ts
+++ b/frontend/src/utils/yorkie/yorkieSync.ts
@@ -10,6 +10,7 @@ export type YorkieCodeMirrorPresenceType = {
 	color: string;
 	name: string;
 	selection: yorkie.TextPosStructRange | null;
+	cursor: [number, number];
 };
 
 export class YorkieSyncConfig<

--- a/frontend/src/utils/yorkie/yorkieSync.ts
+++ b/frontend/src/utils/yorkie/yorkieSync.ts
@@ -10,7 +10,7 @@ export type YorkieCodeMirrorPresenceType = {
 	color: string;
 	name: string;
 	selection: yorkie.TextPosStructRange | null;
-	cursor: [number, number];
+	cursor: [number, number] | null;
 };
 
 export class YorkieSyncConfig<


### PR DESCRIPTION
#### What this PR does / why we need it?
This PR introduces a feature that automatically scrolls to a user's corresponding section in the document when that user's profile is clicked. This functionality is intended to streamline collaboration by minimizing the time users spend searching for specific content tied to team members.

#### Any background context you want to provide?
In collaborative platforms with extensive documentation, such as Figma, enabling users to readily navigate to pertinent sections based on user profiles significantly boosts productivity and fosters more efficient teamwork. This feature is particularly beneficial in lengthy documents where manually locating information can hinder progress.

Note: The scroll navigation feature requires that the user has selected an editor section. If no section is selected, the navigation will not occur. 

#### What are the relevant tickets?
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes https://github.com/yorkie-team/codepair/issues/256

### Checklist
- [x] Added relevant tests or not required
- [x] Didn't break anything

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **New Features**
	- Enhanced user presence component to allow direct navigation to user locations in the editor upon avatar clicks.
	- Introduced a new property for improved tracking of user selections in presence data.

- **Refactor**
	- Streamlined user presence management in the document header component with a new custom hook.
	- Updated the user presence component to improve state management using Redux.
	- Modified the document management hook for enhanced error resilience and maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->