### PR TITLE
Add hyperlink creation feature

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -74,6 +74,7 @@
 				"@types/react-dom": "^18.2.17",
 				"@types/react-infinite-scroller": "^1.2.5",
 				"@types/react-scroll-sync": "^0.9.0",
+				"@types/validator": "^13.12.1",
 				"@typescript-eslint/eslint-plugin": "^6.14.0",
 				"@typescript-eslint/parser": "^6.14.0",
 				"@vitejs/plugin-react": "^4.2.1",
@@ -2803,6 +2804,12 @@
 			"resolved": "https://registry.npmjs.org/@types/use-sync-external-store/-/use-sync-external-store-0.0.3.tgz",
 			"integrity": "sha512-EwmlvuaxPNej9+T4v5AuBPJa2x2UOJVdjCtDHgcDqitUeOtjnJKJ+apYjVcAoBEMjKW1VVFGZLUb5+qqa09XFA==",
 			"license": "MIT"
+		},
+		"node_modules/@types/validator": {
+			"version": "13.12.1",
+			"resolved": "https://registry.npmjs.org/@types/validator/-/validator-13.12.1.tgz",
+			"integrity": "sha512-w0URwf7BQb0rD/EuiG12KP0bailHKHP5YVviJG9zw3ykAokL0TuxU2TUqMB7EwZ59bDHYdeTIvjI5m0S7qHfOA==",
+			"dev": true
 		},
 		"node_modules/@typescript-eslint/eslint-plugin": {
 			"version": "6.21.0",

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -60,6 +60,7 @@
 				"rehype-rewrite": "^4.0.2",
 				"rehype-sanitize": "^6.0.0",
 				"remark-math": "^6.0.0",
+				"validator": "^13.12.0",
 				"vite-plugin-package-version": "^1.1.0",
 				"yorkie-js-sdk": "0.4.31"
 			},
@@ -8667,6 +8668,14 @@
 			"license": "MIT",
 			"peerDependencies": {
 				"react": "^16.8.0 || ^17.0.0 || ^18.0.0"
+			}
+		},
+		"node_modules/validator": {
+			"version": "13.12.0",
+			"resolved": "https://registry.npmjs.org/validator/-/validator-13.12.0.tgz",
+			"integrity": "sha512-c1Q0mCiPlgdTVVVIJIrBuxNicYE+t/7oKeI9MWLj3fh/uq2Pxh/3eeWbVZ4OcGW1TUf53At0njHw5SMdA3tmMg==",
+			"engines": {
+				"node": ">= 0.10"
 			}
 		},
 		"node_modules/vfile": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -73,6 +73,7 @@
 		"rehype-rewrite": "^4.0.2",
 		"rehype-sanitize": "^6.0.0",
 		"remark-math": "^6.0.0",
+		"validator": "^13.12.0",
 		"vite-plugin-package-version": "^1.1.0",
 		"yorkie-js-sdk": "0.4.31"
 	},

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -87,6 +87,7 @@
 		"@types/react-dom": "^18.2.17",
 		"@types/react-infinite-scroller": "^1.2.5",
 		"@types/react-scroll-sync": "^0.9.0",
+		"@types/validator": "^13.12.1",
 		"@typescript-eslint/eslint-plugin": "^6.14.0",
 		"@typescript-eslint/parser": "^6.14.0",
 		"@vitejs/plugin-react": "^4.2.1",

--- a/frontend/src/components/editor/Editor.tsx
+++ b/frontend/src/components/editor/Editor.tsx
@@ -15,6 +15,7 @@ import { selectSetting } from "../../store/settingSlice";
 import { selectWorkspace } from "../../store/workspaceSlice";
 import { imageUploader } from "../../utils/imageUploader";
 import { intelligencePivot } from "../../utils/intelligence/intelligencePivot";
+import { urlHyperlinkInserter } from "../../utils/urlHyperlinkInserter";
 import { yorkieCodeMirror } from "../../utils/yorkie";
 import ToolBar from "./ToolBar";
 
@@ -78,6 +79,7 @@ function Editor() {
 				...(settingStore.fileUpload.enable
 					? [imageUploader(handleUploadImage, editorStore.doc)]
 					: []),
+				urlHyperlinkInserter(editorStore.doc),
 			],
 		});
 

--- a/frontend/src/hooks/useFormatUtils.ts
+++ b/frontend/src/hooks/useFormatUtils.ts
@@ -143,10 +143,26 @@ export const useFormatUtils = () => {
 		[cmView, applyFormat]
 	);
 
+	const checkAndAddFormat = useCallback(
+		(
+			selectedTextStart: string,
+			selectedTextEnd: string,
+			marker: string,
+			format: FormatType,
+			formats: Set<FormatType>
+		) => {
+			if (selectedTextStart.includes(marker) && selectedTextEnd.includes(marker)) {
+				formats.add(format);
+			}
+		},
+		[]
+	);
+
 	return {
 		getFormatMarkerLength,
 		applyFormat,
 		setKeymapConfig,
 		toggleButtonChangeHandler,
+		checkAndAddFormat,
 	};
 };

--- a/frontend/src/hooks/useToolBar.ts
+++ b/frontend/src/hooks/useToolBar.ts
@@ -1,0 +1,68 @@
+import { useCallback, useState } from "react";
+import { FormatType, ToolBarState, useFormatUtils } from "./useFormatUtils";
+import { ViewUpdate } from "@codemirror/view";
+
+export const useToolBar = () => {
+	const [toolBarState, setToolBarState] = useState<ToolBarState>({
+		show: false,
+		position: { top: 0, left: 0 },
+		selectedFormats: new Set<FormatType>(),
+	});
+	const { getFormatMarkerLength } = useFormatUtils();
+
+	const updateFormatBar = useCallback(
+		(update: ViewUpdate) => {
+			const selection = update.state.selection.main;
+			if (!selection.empty) {
+				const coords = update.view.coordsAtPos(selection.from);
+				if (coords) {
+					const maxLength = getFormatMarkerLength(update.view.state, selection.from);
+
+					const selectedTextStart = update.state.sliceDoc(
+						selection.from - maxLength,
+						selection.from
+					);
+					const selectedTextEnd = update.state.sliceDoc(
+						selection.to,
+						selection.to + maxLength
+					);
+					const formats = new Set<FormatType>();
+
+					const checkAndAddFormat = (marker: string, format: FormatType) => {
+						if (
+							selectedTextStart.includes(marker) &&
+							selectedTextEnd.includes(marker)
+						) {
+							formats.add(format);
+						}
+					};
+
+					checkAndAddFormat("**", FormatType.BOLD);
+					checkAndAddFormat("_", FormatType.ITALIC);
+					checkAndAddFormat("`", FormatType.CODE);
+					checkAndAddFormat("~~", FormatType.STRIKETHROUGH);
+
+					// TODO: Modify the rendering method so that it is not affected by the size of the Toolbar
+					setToolBarState((prev) => ({
+						...prev,
+						show: true,
+						position: {
+							top: coords.top - 5,
+							left: coords.left,
+						},
+						selectedFormats: formats,
+					}));
+				}
+			} else {
+				setToolBarState((prev) => ({
+					...prev,
+					show: false,
+					selectedFormats: new Set(),
+				}));
+			}
+		},
+		[getFormatMarkerLength]
+	);
+
+	return { toolBarState, setToolBarState, updateFormatBar };
+};

--- a/frontend/src/hooks/useToolBar.ts
+++ b/frontend/src/hooks/useToolBar.ts
@@ -8,60 +8,52 @@ export const useToolBar = () => {
 		position: { top: 0, left: 0 },
 		selectedFormats: new Set<FormatType>(),
 	});
-	const { getFormatMarkerLength } = useFormatUtils();
+	const { getFormatMarkerLength, checkAndAddFormat } = useFormatUtils();
 
 	const updateFormatBar = useCallback(
 		(update: ViewUpdate) => {
-			const selection = update.state.selection.main;
-			if (!selection.empty) {
-				const coords = update.view.coordsAtPos(selection.from);
-				if (coords) {
-					const maxLength = getFormatMarkerLength(update.view.state, selection.from);
+			const { state, view } = update;
+			const selection = state.selection.main;
 
-					const selectedTextStart = update.state.sliceDoc(
-						selection.from - maxLength,
-						selection.from
-					);
-					const selectedTextEnd = update.state.sliceDoc(
-						selection.to,
-						selection.to + maxLength
-					);
-					const formats = new Set<FormatType>();
-
-					const checkAndAddFormat = (marker: string, format: FormatType) => {
-						if (
-							selectedTextStart.includes(marker) &&
-							selectedTextEnd.includes(marker)
-						) {
-							formats.add(format);
-						}
-					};
-
-					checkAndAddFormat("**", FormatType.BOLD);
-					checkAndAddFormat("_", FormatType.ITALIC);
-					checkAndAddFormat("`", FormatType.CODE);
-					checkAndAddFormat("~~", FormatType.STRIKETHROUGH);
-
-					// TODO: Modify the rendering method so that it is not affected by the size of the Toolbar
-					setToolBarState((prev) => ({
-						...prev,
-						show: true,
-						position: {
-							top: coords.top - 5,
-							left: coords.left,
-						},
-						selectedFormats: formats,
-					}));
-				}
-			} else {
+			if (selection.empty) {
 				setToolBarState((prev) => ({
 					...prev,
 					show: false,
 					selectedFormats: new Set(),
 				}));
+				return;
 			}
+
+			const coords = view.coordsAtPos(selection.from);
+			if (!coords) return;
+
+			const maxLength = getFormatMarkerLength(view.state, selection.from);
+			const selectedTextStart = state.sliceDoc(selection.from - maxLength, selection.from);
+			const selectedTextEnd = state.sliceDoc(selection.to, selection.to + maxLength);
+			const formats = new Set<FormatType>();
+			const formatChecks = [
+				{ marker: "**", format: FormatType.BOLD },
+				{ marker: "_", format: FormatType.ITALIC },
+				{ marker: "`", format: FormatType.CODE },
+				{ marker: "~~", format: FormatType.STRIKETHROUGH },
+			];
+
+			formatChecks.forEach(({ marker, format }) => {
+				checkAndAddFormat(selectedTextStart, selectedTextEnd, marker, format, formats);
+			});
+
+			// TODO: Modify the rendering method so that it is not affected by the size of the Toolbar
+			setToolBarState((prev) => ({
+				...prev,
+				show: true,
+				position: {
+					top: coords.top - 5,
+					left: coords.left,
+				},
+				selectedFormats: formats,
+			}));
 		},
-		[getFormatMarkerLength]
+		[getFormatMarkerLength, checkAndAddFormat]
 	);
 
 	return { toolBarState, setToolBarState, updateFormatBar };

--- a/frontend/src/utils/urlHyperlinkInserter.ts
+++ b/frontend/src/utils/urlHyperlinkInserter.ts
@@ -1,0 +1,43 @@
+import { EditorView } from "codemirror";
+import { CodePairDocType } from "../store/editorSlice";
+
+const isValidUrl = (url: string) => {
+	// eslint-disable-next-line no-useless-escape
+	const urlRegex = /^(https?|ftp):\/\/(-\.)?([^\s\/?\.#-]+\.?)+(\/[^\s]*)?$/i;
+	return urlRegex.test(url);
+};
+
+const insertLinkToEditor = (url: string, view: EditorView, doc: CodePairDocType) => {
+	const { from, to } = view.state.selection.main;
+	const selectedText = view.state.sliceDoc(from, to);
+	const insert = `[${selectedText}](${url})`;
+
+	doc.update((root, presence) => {
+		root.content.edit(from, to, insert);
+		presence.set({
+			selection: root.content.indexRangeToPosRange([
+				from + insert.length,
+				from + insert.length,
+			]),
+		});
+	});
+
+	view.dispatch({
+		changes: { from, to, insert },
+		selection: {
+			anchor: from + insert.length,
+		},
+	});
+};
+
+export const urlHyperlinkInserter = (doc: CodePairDocType) => {
+	return EditorView.domEventHandlers({
+		paste(event, view) {
+			const url = event.clipboardData?.getData("text/plain");
+			if (!url || !isValidUrl(url)) return;
+
+			insertLinkToEditor(url, view, doc);
+			event.preventDefault();
+		},
+	});
+};

--- a/frontend/src/utils/urlHyperlinkInserter.ts
+++ b/frontend/src/utils/urlHyperlinkInserter.ts
@@ -1,10 +1,9 @@
 import { EditorView } from "codemirror";
+import validator from "validator";
 import { CodePairDocType } from "../store/editorSlice";
 
 const isValidUrl = (url: string) => {
-	// eslint-disable-next-line no-useless-escape
-	const urlRegex = /^(https?|ftp):\/\/(-\.)?([^\s\/?\.#-]+\.?)+(\/[^\s]*)?$/i;
-	return urlRegex.test(url);
+	return validator.isURL(url);
 };
 
 const insertLinkToEditor = (url: string, view: EditorView, doc: CodePairDocType) => {

--- a/frontend/src/utils/urlHyperlinkInserter.ts
+++ b/frontend/src/utils/urlHyperlinkInserter.ts
@@ -36,6 +36,9 @@ export const urlHyperlinkInserter = (doc: CodePairDocType) => {
 			const url = event.clipboardData?.getData("text/plain");
 			if (!url || !isValidUrl(url)) return;
 
+			const { from, to } = view.state.selection.main;
+			if (from === to) return;
+
 			insertLinkToEditor(url, view, doc);
 			event.preventDefault();
 		},


### PR DESCRIPTION

#### What this PR does / why we need it?
This PR introduces a feature that enhances text selection by enabling the automatic creation of hyperlinks when dragging and selecting text prior to pasting a link. Currently, users experience the inconvenience of having URLs pasted directly into the text instead of being applied as hyperlinks to the selected text. 

With this enhancement, the system will automatically detect if the copied content is a link and generate a Markdown link format that connects the selected text with the URL, thus improving the overall user experience.

#### Any background context you want to provide?
Streamlining the hyperlink creation process will not only save time for users but also ensure that linking text is more intuitive. This is particularly useful for users who frequently need to reference external sources, as they can now create clickable links with a simple drag-and-select action, enhancing productivity and usability.

#### What are the relevant tickets?
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes https://github.com/yorkie-team/codepair/issues/322

### Checklist
- [x] Added relevant tests or not required
- [x] Didn't break anything

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **New Features**
	- Introduced a new toolbar management system for improved formatting options in the editor.
	- Added functionality for seamless hyperlink insertion from the clipboard, enhancing user experience.

- **Bug Fixes**
	- Streamlined the toolbar's visibility and selected formats, improving responsiveness to user interactions.

- **Chores**
	- Removed unused imports to enhance code clarity and maintainability.
	- Updated dependencies for enhanced type support and validation functionalities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->