### PR TITLE
Ensure correct representation of logged-in users in shared document view

### DIFF
--- a/frontend/src/pages/workspace/document/share/Index.tsx
+++ b/frontend/src/pages/workspace/document/share/Index.tsx
@@ -1,19 +1,24 @@
 import { Box } from "@mui/material";
+import { useEffect, useMemo } from "react";
+import { useDispatch, useSelector } from "react-redux";
+import { Navigate, useLocation, useSearchParams } from "react-router-dom";
 import DocumentView from "../../../../components/editor/DocumentView";
 import { useGetDocumentBySharingTokenQuery } from "../../../../hooks/api/document";
-import { Navigate, useLocation, useSearchParams } from "react-router-dom";
-import { useEffect, useMemo } from "react";
 import { useYorkieDocument } from "../../../../hooks/useYorkieDocument";
-import { useDispatch } from "react-redux";
 import { setClient, setDoc, setMode, setShareRole } from "../../../../store/editorSlice";
+import { selectUser } from "../../../../store/userSlice";
 
 function DocumentShareIndex() {
 	const dispatch = useDispatch();
 	const location = useLocation();
 	const [searchParams] = useSearchParams();
+	const userStore = useSelector(selectUser);
 	const shareToken = useMemo(() => searchParams.get("token"), [searchParams]);
 	const { data: sharedDocument } = useGetDocumentBySharingTokenQuery(shareToken);
-	const { doc, client } = useYorkieDocument(sharedDocument?.yorkieDocumentId, "Anonymous");
+	const { doc, client } = useYorkieDocument(
+		sharedDocument?.yorkieDocumentId,
+		userStore.data?.nickname ?? "Anonymous"
+	);
 
 	useEffect(() => {
 		if (!sharedDocument?.role) return;


### PR DESCRIPTION
#### What this PR does / why we need it?
This PR fixes the problem where users are erroneously identified as anonymous in shared documents despite being logged in. The aim is to make sure the system accurately recognizes and displays the user's login status when they access shared documents.

#### Any background context you want to provide?
Users have encountered a situation where their identity is shown as anonymous when they open shared documents. This issue seems to originate from problems relating to authentication or session management, which can potentially confuse users who expect to see their logged-in status.

#### What are the relevant tickets?
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes https://github.com/yorkie-team/codepair/issues/148

### Checklist
- [x] Added relevant tests or not required
- [x] Didn't break anything

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced document sharing functionality by personalizing user nicknames instead of using a generic label.
	- Users will now see their own nickname when sharing documents, improving the overall user experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->