### PR TITLE
Remove unnecessary `LANGCHAIN_ENDPOINT` environment variable due to LangSmith API Key update

### DIFF
--- a/backend/.env.development
+++ b/backend/.env.development
@@ -51,13 +51,8 @@ OPENAI_API_KEY=your_openai_api_key_here
 
 # LANGCHAIN_TRACING_V2: Whether LangSmith monitoring for YorkieIntelligence is needed.
 # Set to true if LangSmith monitoring is required.
-# If set to false, LANGCHAIN_ENDPOINT, LANGCHAIN_API_KEY, and LANGCHAIN_PROJECT are not required.
+# If set to false, LANGCHAIN_API_KEY, and LANGCHAIN_PROJECT are not required.
 LANGCHAIN_TRACING_V2=false
-# LANGCHAIN_ENDPOINT: LangSmith API URL.
-# This URL is used to communicate with LangSmith.
-# Example: https://api.smith.langchain.com
-# To obtain the LangSmith endpoint, visit LangSmith: https://www.langchain.com/langsmith
-LANGCHAIN_ENDPOINT=https://www.langchain.com/langsmith
 # LANGCHAIN_API_KEY: LangSmith API Key.
 # This key is required for authenticating with LangSmith.
 # To obtain an API key, visit LangSmith: https://www.langchain.com/langsmith

--- a/backend/docker/docker-compose-full.yml
+++ b/backend/docker/docker-compose-full.yml
@@ -7,6 +7,7 @@ services:
         environment:
             DATABASE_URL: "mongodb://mongo:27017/codepair"
             # Environment variables need to be passed to the container
+            # You can find the description of each environment variable in the backend/.env.development file
             GITHUB_CLIENT_ID: "your_github_client_id_here"
             GITHUB_CLIENT_SECRET: "your_github_client_secret_here"
             GITHUB_CALLBACK_URL: "http://localhost:3000/auth/login/github"
@@ -19,7 +20,7 @@ services:
             YORKIE_INTELLIGENCE: "ollama:gemma2:2b"
             OLLAMA_HOST_URL: http://yorkie-intelligence:11434
             OPENAI_API_KEY: "your_openai_api_key_here"
-            LANGCHAIN_ENDPOINT: "https://www.langchain.com/langsmith"
+            LANGCHAIN_TRACING_V2: "false"
             LANGCHAIN_API_KEY: "your_langsmith_api_key_here"
             LANGCHAIN_PROJECT: "your_langsmith_project_name_here"
             FILE_UPLOAD: false


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

**What this PR does / why we need it**:
This PR removes the `LANGCHAIN_ENDPOINT` environment variable, as it is no longer needed following the update of the API Key in LangSmith.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

**Special notes for your reviewer**:
The recent updates to the LangSmith API Key have made the `LANGCHAIN_ENDPOINT` obsolete. This change reflects an effort to streamline environment variable management and enhance overall ease of use.

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```

**Additional documentation**:

<!--
This section can be blank if this pull request does not require a release note.

Please use the following format for linking documentation:
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```

**Checklist**:
- [x] Added relevant tests or not required
- [x] Didn't break anything
