### PR TITLE
Add ability to modify document titles

### DIFF
--- a/backend/.env.development
+++ b/backend/.env.development
@@ -5,10 +5,10 @@ DATABASE_URL=mongodb://localhost:27017/codepair
 
 # GITHUB_CLIENT_ID: Client ID for authenticating with GitHub.
 # To obtain a client ID, create an OAuth app at: https://docs.github.com/en/apps/oauth-apps/building-oauth-apps/creating-an-oauth-app
-GITHUB_CLIENT_ID=your_github_client_id_here
+GITHUB_CLIENT_ID=Iv23li1CysRsALb97SET
 # GITHUB_CLIENT_SECRET: Client secret for authenticating with GitHub.
 # To obtain a client ID, create an OAuth app at: https://docs.github.com/en/apps/oauth-apps/building-oauth-apps/creating-an-oauth-app
-GITHUB_CLIENT_SECRET=your_github_client_secret_here
+GITHUB_CLIENT_SECRET=74014d1b2b845c852793128153b50623837b31d3
 # GITHUB_CALLBACK_URL: Callback URL for handling GitHub authentication response.
 # Format: https://<backend_url>/auth/login/github
 # Example: http://localhost:3000/auth/login/github (For development mode)

--- a/backend/docker/docker-compose-full.yml
+++ b/backend/docker/docker-compose-full.yml
@@ -7,8 +7,8 @@ services:
         environment:
             DATABASE_URL: "mongodb://mongo:27017/codepair"
             # Environment variables need to be passed to the container
-            GITHUB_CLIENT_ID: "your_github_client_id_here"
-            GITHUB_CLIENT_SECRET: "your_github_client_secret_here"
+            GITHUB_CLIENT_ID: "Iv23li1CysRsALb97SET"
+            GITHUB_CLIENT_SECRET: "74014d1b2b845c852793128153b50623837b31d3"
             GITHUB_CALLBACK_URL: "http://localhost:3000/auth/login/github"
             JWT_AUTH_SECRET: "you_should_change_this_secret_key_in_production"
             FRONTEND_BASE_URL: "http://localhost:5173"

--- a/backend/src/workspace-documents/dto/update-document-title.dto.ts
+++ b/backend/src/workspace-documents/dto/update-document-title.dto.ts
@@ -1,0 +1,13 @@
+import { ApiProperty } from "@nestjs/swagger";
+import { IsString, IsNotEmpty } from "class-validator";
+
+export class UpdateDocumentTitleDto {
+	@ApiProperty({
+		description: "The new title of the document",
+		example: "Updated Document Title",
+		type: String,
+	})
+	@IsString()
+	@IsNotEmpty()
+	title: string;
+}

--- a/backend/src/workspace-documents/workspace-documents.controller.ts
+++ b/backend/src/workspace-documents/workspace-documents.controller.ts
@@ -6,6 +6,7 @@ import {
 	Param,
 	ParseIntPipe,
 	Post,
+	Put,
 	Query,
 	Req,
 } from "@nestjs/common";
@@ -24,6 +25,7 @@ import {
 import { AuthroizedRequest } from "src/utils/types/req.type";
 import { CreateWorkspaceDocumentDto } from "./dto/create-workspace-document.dto";
 import { CreateWorkspaceDocumentResponse } from "./types/create-workspace-document-response.type";
+import { UpdateDocumentTitleDto } from "./dto/update-document-title.dto";
 import { HttpExceptionResponse } from "src/utils/types/http-exception-response.type";
 import { FindWorkspaceDocumentsResponse } from "./types/find-workspace-documents-response.type";
 import { CreateWorkspaceDocumentShareTokenResponse } from "./types/create-workspace-document-share-token-response.type";
@@ -36,6 +38,39 @@ import { FindWorkspaceDocumentResponse } from "./types/find-workspace-document-r
 export class WorkspaceDocumentsController {
 	constructor(private workspaceDocumentsService: WorkspaceDocumentsService) {}
 
+	// PUT endpoint for updating document title
+	@Put(":document_id/title")
+	@ApiOperation({
+		summary: "Update the title of a document in the workspace",
+		description: "If the user has the access permissions, update the document's title.",
+	})
+	@ApiOkResponse({
+		description: "Document title updated successfully",
+	})
+	@ApiNotFoundResponse({
+		type: HttpExceptionResponse,
+		description:
+			"The workspace or document does not exist, or the user lacks the appropriate permissions.",
+	})
+	@ApiBody({
+		description: "The new title of the document",
+		type: UpdateDocumentTitleDto,
+	})
+	async updateTitle(
+		@Param("workspace_id") workspaceId: string,
+		@Param("document_id") documentId: string,
+		@Body() updateDocumentTitleDto: UpdateDocumentTitleDto,
+		@Req() req: AuthroizedRequest
+	): Promise<void> {
+		await this.workspaceDocumentsService.updateTitle(
+			req.user.id,
+			workspaceId,
+			documentId,
+			updateDocumentTitleDto.title
+		);
+	}
+
+	// Get the list of documents in the workspace
 	@Get("")
 	@ApiOperation({
 		summary: "Retrieve the Documents in Workspace",
@@ -68,6 +103,7 @@ export class WorkspaceDocumentsController {
 		return this.workspaceDocumentsService.findMany(req.user.id, workspaceId, pageSize, cursor);
 	}
 
+	// Get a specific document by ID
 	@Get(":document_id")
 	@ApiOperation({
 		summary: "Retrieve a Document in the Workspace",
@@ -87,6 +123,7 @@ export class WorkspaceDocumentsController {
 		return this.workspaceDocumentsService.findOne(req.user.id, workspaceId, documentId);
 	}
 
+	// Create a new document in the workspace
 	@Post()
 	@ApiOperation({
 		summary: "Create a Document in a Workspace",
@@ -110,6 +147,7 @@ export class WorkspaceDocumentsController {
 		);
 	}
 
+	// Generate a share token for a document
 	@Post(":document_id/share-token")
 	@ApiOperation({
 		summary: "Retrieve a Share Token for the Document",

--- a/backend/src/workspace-documents/workspace-documents.service.ts
+++ b/backend/src/workspace-documents/workspace-documents.service.ts
@@ -17,6 +17,30 @@ export class WorkspaceDocumentsService {
 		private configService: ConfigService
 	) {}
 
+	async updateTitle(
+		userId: string,
+		workspaceId: string,
+		documentId: string,
+		title: string
+	): Promise<void> {
+		const document = await this.prismaService.document.findFirst({
+			where: {
+				id: documentId,
+				workspaceId: workspaceId,
+			},
+		});
+
+		if (!document) {
+			throw new NotFoundException("Document not found");
+		}
+
+		// Update the document's title
+		await this.prismaService.document.update({
+			where: { id: documentId },
+			data: { title: title },
+		});
+	}
+
 	async create(userId: string, workspaceId: string, title: string) {
 		try {
 			await this.prismaService.userWorkspace.findFirstOrThrow({

--- a/frontend/src/components/editor/Editor.tsx
+++ b/frontend/src/components/editor/Editor.tsx
@@ -170,26 +170,31 @@ function Editor() {
 	]);
 
 	return (
-		<ScrollSyncPane>
-			<div
-				style={{
-					height: "100%",
-					overflow: "auto",
-				}}
-			>
+		<>
+			<ScrollSyncPane>
 				<div
-					ref={ref}
 					style={{
-						display: "flex",
-						alignItems: "stretch",
-						minHeight: "100%",
+						height: "100%",
+						overflow: "auto",
 					}}
-				/>
-				{Boolean(toolBarState.show) && (
-					<ToolBar toolBarState={toolBarState} onChangeToolBarState={setToolBarState} />
-				)}
-			</div>
-		</ScrollSyncPane>
+				>
+					<div
+						ref={ref}
+						style={{
+							display: "flex",
+							alignItems: "stretch",
+							minHeight: "100%",
+						}}
+					/>
+					{Boolean(toolBarState.show) && (
+						<ToolBar
+							toolBarState={toolBarState}
+							onChangeToolBarState={setToolBarState}
+						/>
+					)}
+				</div>
+			</ScrollSyncPane>
+		</>
 	);
 }
 

--- a/frontend/src/components/headers/DocumentHeader.tsx
+++ b/frontend/src/components/headers/DocumentHeader.tsx
@@ -38,12 +38,10 @@ function DocumentHeader() {
 	const editorState = useSelector(selectEditor);
 	const workspaceState = useSelector(selectWorkspace);
 	const { presenceList } = useUserPresence(editorState.doc);
+	const [focused, setFocused] = useState(false);
 	const [documentTitle, setDocumentTitle] = useState("");
 	const params = useParams();
 	const { data: workspace } = useGetWorkspaceQuery(params.workspaceSlug);
-	console.log("Workspace ID:", workspace?.id);
-	console.log("Document ID:", params.documentId);
-	console.log("Title:", documentTitle);
 
 	const { data: documentData } = useGetDocumentQuery(
 		workspace?.id || "",
@@ -54,6 +52,10 @@ function DocumentHeader() {
 		workspace?.id || "",
 		params.documentId || ""
 	);
+
+	const handleFocus = () => {
+		setFocused(true);
+	};
 
 	useEffect(() => {
 		if (editorState.shareRole === "READ") {
@@ -78,6 +80,7 @@ function DocumentHeader() {
 
 	const handleUpdateDocumentTitle = async (data: { title: string }) => {
 		await updateDocumentTitle(data);
+		setFocused(false);
 	};
 
 	useEffect(() => {
@@ -125,14 +128,14 @@ function DocumentHeader() {
 							)}
 						</Paper>
 						<DownloadMenu />
-						{/* added field to update document title */}
-						<Stack gap={4}>
+
+						<Stack alignItems="center">
 							<FormControl>
 								<FormContainer
 									defaultValues={{ title: documentTitle }}
 									onSuccess={handleUpdateDocumentTitle}
 								>
-									<Stack gap={4} alignItems="flex-end">
+									<Stack gap={4} alignItems="flex-end" flexDirection="row">
 										<TextFieldElement
 											variant="standard"
 											name="title"
@@ -143,15 +146,19 @@ function DocumentHeader() {
 												maxLength: 255,
 											}}
 											onChange={handleDocumentTitleChange}
+											onFocus={handleFocus}
 										/>
-										<Button type="submit" variant="contained" size="large">
-											OK
-										</Button>
+										{focused && (
+											<Button type="submit" variant="contained" size="large">
+												Update
+											</Button>
+										)}
 									</Stack>
 								</FormContainer>
 							</FormControl>
 						</Stack>
 					</Stack>
+
 					<Stack direction="row" alignItems="center" gap={1}>
 						<UserPresenceList presenceList={presenceList} />
 						{!editorState.shareRole && <ShareButton />}

--- a/frontend/src/components/headers/DocumentHeader.tsx
+++ b/frontend/src/components/headers/DocumentHeader.tsx
@@ -27,8 +27,10 @@ import UserPresenceList from "./UserPresenceList";
 import { FormContainer, TextFieldElement } from "react-hook-form-mui";
 import { useGetWorkspaceQuery } from "../../hooks/api/workspace";
 
-// Added this query to update the documentname
-import { useUpdateDocumentTitleMutation } from "../../hooks/api/workspaceDocument";
+import {
+	useUpdateDocumentTitleMutation,
+	useGetDocumentQuery,
+} from "../../hooks/api/workspaceDocument";
 
 function DocumentHeader() {
 	const dispatch = useDispatch();
@@ -42,6 +44,11 @@ function DocumentHeader() {
 	console.log("Workspace ID:", workspace?.id);
 	console.log("Document ID:", params.documentId);
 	console.log("Title:", documentTitle);
+
+	const { data: documentData } = useGetDocumentQuery(
+		workspace?.id || "",
+		params.documentId || ""
+	);
 
 	const { mutateAsync: updateDocumentTitle } = useUpdateDocumentTitleMutation(
 		workspace?.id || "",
@@ -72,6 +79,12 @@ function DocumentHeader() {
 	const handleUpdateDocumentTitle = async (data: { title: string }) => {
 		await updateDocumentTitle(data);
 	};
+
+	useEffect(() => {
+		if (documentData && documentData.title) {
+			setDocumentTitle(documentData.title);
+		}
+	}, [documentData]);
 
 	return (
 		<AppBar position="static" sx={{ zIndex: 100 }}>
@@ -116,14 +129,14 @@ function DocumentHeader() {
 						<Stack gap={4}>
 							<FormControl>
 								<FormContainer
-									defaultValues={{ title: "" }}
+									defaultValues={{ title: documentTitle }}
 									onSuccess={handleUpdateDocumentTitle}
 								>
 									<Stack gap={4} alignItems="flex-end">
 										<TextFieldElement
 											variant="standard"
 											name="title"
-											label="document title"
+											label={documentTitle}
 											required
 											fullWidth
 											inputProps={{

--- a/frontend/src/hooks/api/types/document.d.ts
+++ b/frontend/src/hooks/api/types/document.d.ts
@@ -13,3 +13,7 @@ export class Document {
 export class GetDocumentBySharingTokenResponse extends Document {
 	role: ShareRole;
 }
+
+export class UpdateDocumentRequest {
+	title: string;
+}

--- a/frontend/src/hooks/api/workspaceDocument.ts
+++ b/frontend/src/hooks/api/workspaceDocument.ts
@@ -8,9 +8,11 @@ import {
 	GetWorkspaceDocumentResponse,
 	GetWorkspaceDocumentListResponse,
 } from "./types/workspaceDocument";
-import { useDispatch } from "react-redux";
+
 import { useEffect } from "react";
 import { setDocumentData } from "../../store/documentSlice";
+import { UpdateDocumentRequest } from "./types/document";
+import { useDispatch } from "react-redux";
 
 export const generateGetWorkspaceDocumentListQueryKey = (workspaceId: string) => {
 	return ["workspaces", workspaceId, "documents"];
@@ -102,6 +104,26 @@ export const useCreateWorkspaceSharingTokenMutation = (workspaceId: string, docu
 			);
 
 			return res.data;
+		},
+	});
+};
+
+export const useUpdateDocumentTitleMutation = (workspaceId: string, documentId: string) => {
+	const queryClient = useQueryClient();
+
+	return useMutation({
+		mutationFn: async (data: UpdateDocumentRequest) => {
+			const res = await axios.put<void>(
+				`/workspaces/${workspaceId}/documents/${documentId}/title`,
+				data
+			);
+
+			return res.data;
+		},
+		onSuccess: () => {
+			queryClient.invalidateQueries({
+				queryKey: generateGetDocumentQueryKey(workspaceId, documentId),
+			});
 		},
 	});
 };


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

**What this PR does / why we need it**:

Created the logic to update the document title after its created since it would create a better user experience. A title could be misspelled or the content and the needs of that document could change over time.

**Which issue(s) this PR fixes**:

Fixes #143 

**Special notes for your reviewer**:

I am currently studying web development at YRGO in Gothenburg, Sweden, and this contribution is part of an open-source assignment for my coursework. Working on this issue has been an enjoyable and educational experience, and I appreciate the opportunity to contribute to this project.

I welcome any feedback you may have.

Additionally, I want to mention that although I was not initially assigned to this issue, I communicated with the original assignees in the comments, and they confirmed it was fine for me to proceed with the work.

**Does this PR introduce a user-facing change?**:

```release-note

Created an input field in DocumentHeader.tsx where the user can submit the changes to the documents title.

```



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced functionality to update document titles via a new API endpoint.
	- Added a user-friendly form for editing document titles in the Document Header.
	- Implemented a new mutation hook for updating document titles in the application.

- **Bug Fixes**
	- Enhanced GitHub authentication by updating environment variables with actual credentials.

- **Documentation**
	- Improved API documentation for the new document title update functionality.

- **Style**
	- Refined the structure and layout of the Editor component for better usability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->