### PR TITLE
Add missing refresh token settings in `docker-compose-full.yml`

### DIFF
--- a/backend/docker/docker-compose-full.yml
+++ b/backend/docker/docker-compose-full.yml
@@ -11,7 +11,10 @@ services:
             GITHUB_CLIENT_ID: "your_github_client_id_here"
             GITHUB_CLIENT_SECRET: "your_github_client_secret_here"
             GITHUB_CALLBACK_URL: "http://localhost:3000/auth/login/github"
-            JWT_AUTH_SECRET: "you_should_change_this_secret_key_in_production"
+            JWT_ACCESS_TOKEN_SECRET: "you_should_change_this_access_token_secret_key_in_production"
+            JWT_ACCESS_TOKEN_EXPIRATION_TIME: 86400
+            JWT_REFRESH_TOKEN_SECRET: "you_should_change_this_refresh_token_secret_key_in_production"
+            JWT_REFRESH_TOKEN_EXPIRATION_TIME: 604800
             FRONTEND_BASE_URL: "http://localhost:5173"
             YORKIE_API_ADDR: "http://yorkie:8080"
             YORKIE_PROJECT_NAME: "default"

--- a/backend/src/check/check.module.ts
+++ b/backend/src/check/check.module.ts
@@ -11,8 +11,10 @@ import { JwtModule } from "@nestjs/jwt";
 			global: true,
 			useFactory: async (configService: ConfigService) => {
 				return {
-					signOptions: { expiresIn: "24h" },
-					secret: configService.get<string>("JWT_AUTH_SECRET"),
+					secret: configService.get<string>("JWT_ACCESS_TOKEN_SECRET"),
+					signOptions: {
+						expiresIn: `${configService.get("JWT_ACCESS_TOKEN_EXPIRATION_TIME")}s`,
+					},
 				};
 			},
 			inject: [ConfigService],


### PR DESCRIPTION
#### What this PR does / why we need it?
This PR adds the necessary refresh token settings to the `docker-compose-full.yml` file. The absence of these settings currently prevents users from logging in when the application is run in Frontend Development Only Mode.

#### Any background context you want to provide?
Users have reported issues with logging in while using Frontend Development Only Mode because the refresh token configuration is not included in the `docker-compose-full.yml`. This PR aims to resolve that issue and ensure smooth user authentication.

#### What are the relevant tickets?
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

### Checklist
- [x] Added relevant tests or not required
- [x] Didn't break anything

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced JWT authentication with separate access and refresh tokens for improved security.
	- Introduced configurable expiration times for access and refresh tokens.

- **Bug Fixes**
	- Updated token management to reflect clearer naming conventions and dynamic expiration settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->