### PR TITLE
Prevent dragging selection of identical characters in CodeMirror

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -24,6 +24,7 @@
 				"@sentry/react": "^7.99.0",
 				"@swc/helpers": "^0.5.3",
 				"@tanstack/react-query": "^5.17.15",
+				"@uiw/codemirror-extensions-basic-setup": "^4.23.2",
 				"@uiw/codemirror-theme-xcode": "^4.21.21",
 				"@uiw/codemirror-themes": "^4.21.21",
 				"@uiw/react-markdown-preview": "^5.0.7",
@@ -3060,6 +3061,32 @@
 			"funding": {
 				"type": "opencollective",
 				"url": "https://opencollective.com/typescript-eslint"
+			}
+		},
+		"node_modules/@uiw/codemirror-extensions-basic-setup": {
+			"version": "4.23.2",
+			"resolved": "https://registry.npmjs.org/@uiw/codemirror-extensions-basic-setup/-/codemirror-extensions-basic-setup-4.23.2.tgz",
+			"integrity": "sha512-eacivkj7wzskl2HBYs4rfN0CbYlsSQh5ADtOYWTpc8Txm4ONw8RTi4/rxF6Ks2vdaovizewU5QaHximbxoNTrw==",
+			"dependencies": {
+				"@codemirror/autocomplete": "^6.0.0",
+				"@codemirror/commands": "^6.0.0",
+				"@codemirror/language": "^6.0.0",
+				"@codemirror/lint": "^6.0.0",
+				"@codemirror/search": "^6.0.0",
+				"@codemirror/state": "^6.0.0",
+				"@codemirror/view": "^6.0.0"
+			},
+			"funding": {
+				"url": "https://jaywcjlove.github.io/#/sponsor"
+			},
+			"peerDependencies": {
+				"@codemirror/autocomplete": ">=6.0.0",
+				"@codemirror/commands": ">=6.0.0",
+				"@codemirror/language": ">=6.0.0",
+				"@codemirror/lint": ">=6.0.0",
+				"@codemirror/search": ">=6.0.0",
+				"@codemirror/state": ">=6.0.0",
+				"@codemirror/view": ">=6.0.0"
 			}
 		},
 		"node_modules/@uiw/codemirror-theme-xcode": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -37,6 +37,7 @@
 		"@sentry/react": "^7.99.0",
 		"@swc/helpers": "^0.5.3",
 		"@tanstack/react-query": "^5.17.15",
+		"@uiw/codemirror-extensions-basic-setup": "^4.23.2",
 		"@uiw/codemirror-theme-xcode": "^4.21.21",
 		"@uiw/codemirror-themes": "^4.21.21",
 		"@uiw/react-markdown-preview": "^5.0.7",

--- a/frontend/src/components/editor/Editor.tsx
+++ b/frontend/src/components/editor/Editor.tsx
@@ -2,8 +2,9 @@ import { markdown } from "@codemirror/lang-markdown";
 import { EditorState } from "@codemirror/state";
 import { keymap } from "@codemirror/view";
 import { Vim, vim } from "@replit/codemirror-vim";
+import { basicSetup } from "@uiw/codemirror-extensions-basic-setup";
 import { xcodeDark, xcodeLight } from "@uiw/codemirror-theme-xcode";
-import { basicSetup, EditorView } from "codemirror";
+import { EditorView } from "codemirror";
 import { useCallback, useEffect, useState } from "react";
 import { useDispatch, useSelector } from "react-redux";
 import { ScrollSyncPane } from "react-scroll-sync";
@@ -73,7 +74,7 @@ function Editor(props: EditorProps) {
 			doc: editorStore.doc.getRoot().content?.toString() ?? "",
 			extensions: [
 				keymap.of(setKeymapConfig()),
-				basicSetup,
+				basicSetup({ highlightSelectionMatches: false }),
 				markdown(),
 				configStore.codeKey === CodeKeyType.VIM ? vim() : [],
 				themeMode == "light" ? xcodeLight : xcodeDark,


### PR DESCRIPTION
#### What this PR does / why we need it?
This PR addresses an unexpected behavior in CodeMirror where dragging to select text allows the selection of identical characters. This feature implementation aims to exclude repeated characters from the selection during the drag action, enhancing the user experience.

#### Any background context you want to provide?
The current iteration of CodeMirror facilitates extensive functionality as a code editor. However, it also results in some selections that may not align with user expectations. By preventing the selection of identical characters during a drag action, we can improve the intuitiveness and functionality of text selection in the editor.

#### What are the relevant tickets?
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes https://github.com/yorkie-team/codepair/issues/339

### Checklist
- [x] Added relevant tests or not required
- [x] Didn't break anything

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Integrated a new dependency to enhance the CodeMirror editor experience.
  
- **Bug Fixes**
	- Adjusted the CodeMirror editor configuration to disable selection match highlighting, improving text selection interaction.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->