### PR TITLE
Reorder keybinding addition for VIM in CodeMirror6

### DIFF
--- a/frontend/src/components/editor/Editor.tsx
+++ b/frontend/src/components/editor/Editor.tsx
@@ -73,10 +73,10 @@ function Editor(props: EditorProps) {
 		const state = EditorState.create({
 			doc: editorStore.doc.getRoot().content?.toString() ?? "",
 			extensions: [
+				configStore.codeKey === CodeKeyType.VIM ? vim() : [],
 				keymap.of(setKeymapConfig()),
 				basicSetup({ highlightSelectionMatches: false }),
 				markdown(),
-				configStore.codeKey === CodeKeyType.VIM ? vim() : [],
 				themeMode == "light" ? xcodeLight : xcodeDark,
 				EditorView.theme({ "&": { width: "100%" } }),
 				EditorView.lineWrapping,


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

**What this PR does / why we need it**:
This PR modifies the order of keybinding addition for VIM in CodeMirror6. It ensures that the VIM keybinding is added first, allowing for the correct application of VIM functionalities.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

**Special notes for your reviewer**:
When integrating VIM keybindings into CodeMirror6, the sequence of addition is crucial. If the VIM keybinding is not added first, it may lead to incomplete or faulty VIM functionality. This change addresses that issue by adjusting the order of operations.

- Reference: https://github.com/replit/codemirror-vim?tab=readme-ov-file#usage

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```

**Additional documentation**:

<!--
This section can be blank if this pull request does not require a release note.

Please use the following format for linking documentation:
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```

**Checklist**:
- [x] Added relevant tests or not required
- [x] Didn't break anything


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Improved initialization of the Vim extension in the editor, ensuring better functionality and responsiveness when using Vim keybindings.
  
- **Bug Fixes**
	- Resolved potential issues with the order of extensions, enhancing overall editor performance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->