### PR TITLE
Fix issue where `jj` could not be entered in Vim mode

### DIFF
--- a/frontend/src/components/editor/Editor.tsx
+++ b/frontend/src/components/editor/Editor.tsx
@@ -1,7 +1,7 @@
 import { markdown } from "@codemirror/lang-markdown";
 import { EditorState } from "@codemirror/state";
 import { keymap } from "@codemirror/view";
-import { Vim, vim } from "@replit/codemirror-vim";
+import { vim } from "@replit/codemirror-vim";
 import { basicSetup } from "@uiw/codemirror-extensions-basic-setup";
 import { xcodeDark, xcodeLight } from "@uiw/codemirror-theme-xcode";
 import { EditorView } from "codemirror";

--- a/frontend/src/components/editor/Editor.tsx
+++ b/frontend/src/components/editor/Editor.tsx
@@ -94,9 +94,6 @@ function Editor(props: EditorProps) {
 			],
 		});
 
-		// Vim key mapping: Map 'jj' to '<Esc>' in insert mode
-		Vim.map("jj", "<Esc>", "insert");
-
 		const view = new EditorView({ state, parent: element });
 		dispatch(setCmView(view));
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

**What this PR does / why we need it**:

Fix issue where `jj` could not be entered in Vim mode

https://github.com/replit/codemirror-vim?tab=readme-ov-file#map-keys

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```

**Additional documentation**:

<!--
This section can be blank if this pull request does not require a release note.

Please use the following format for linking documentation:
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```

**Checklist**:
- [x] Added relevant tests or not required
- [x] Didn't break anything


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Removed the 'jj' key mapping for exiting insert mode in the editor, which may impact Vim users' navigation experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->