### PR TITLE
Change font color of the panel in VIM mode for improved visibility

### DIFF
--- a/frontend/src/components/editor/editor.css
+++ b/frontend/src/components/editor/editor.css
@@ -1,3 +1,7 @@
 .wmde-markdown {
 	background-color: transparent;
 }
+
+.cm-vim-panel input {
+	color: inherit;
+}


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

**What this PR does / why we need it**:
<img width="107" alt="image" src="https://github.com/user-attachments/assets/74c1efa2-6b9f-4147-85a7-30910e711005">
This PR changes the font color of the panel displayed during search in VIM mode. Previously, the text was displayed in black in Dark Mode, making it difficult to read. The modification allows the font to inherit the system color, improving visibility and user experience.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```

**Additional documentation**:

<!--
This section can be blank if this pull request does not require a release note.

Please use the following format for linking documentation:
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```

**Checklist**:
- [x] Added relevant tests or not required
- [x] Didn't break anything
