### PR TITLE
Fix abnormal line spacing in Markdown lists caused by Soft Line Breaks

### DIFF
--- a/frontend/src/utils/document.ts
+++ b/frontend/src/utils/document.ts
@@ -5,6 +5,9 @@ export function createDocumentKey() {
 export function addSoftLineBreak(text: string) {
 	return text
 		.split("\n")
-		.map((line) => line + "  ")
+		.map((line) => {
+			if (line.trim() === "") return "";
+			else return line + "  ";
+		})
 		.join("\n");
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

**What this PR does / why we need it**:
This PR addresses an issue where the line spacing in Markdown lists appears excessively wide due to the addition of Soft Line Breaks. The changes ensure that new line breaks are not added to lines that consist solely of whitespace, thus preserving the intended appearance of lists.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #338 

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```

**Additional documentation**:

<!--
This section can be blank if this pull request does not require a release note.

Please use the following format for linking documentation:
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```

**Checklist**:
- [x] Added relevant tests or not required
- [x] Didn't break anything


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Improved handling of empty lines in text formatting, reducing unnecessary whitespace in outputs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->