### PR TITLE
Add bottom padding to MarkdownPreview

### DIFF
--- a/frontend/src/components/editor/Preview.tsx
+++ b/frontend/src/components/editor/Preview.tsx
@@ -49,6 +49,9 @@ function Preview() {
 
 	return (
 		<MarkdownPreview
+			style={{
+				paddingBottom: "2rem",
+			}}
 			source={addSoftLineBreak(content)}
 			wrapperElement={{
 				"data-color-mode": currentTheme,


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

**What this PR does / why we need it**:

Adds bottom padding to `MarkdownPreview` component

<img width="827" alt="image" src="https://github.com/user-attachments/assets/e82cb354-08b8-455d-a197-0b63f6c18bd1">


**Which issue(s) this PR fixes**:

Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```

**Additional documentation**:

<!--
This section can be blank if this pull request does not require a release note.

Please use the following format for linking documentation:
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```

**Checklist**:
- [x] Added relevant tests or not required
- [x] Didn't break anything


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced rendering for mathematical content, including support for KaTeX math expressions.
	- Improved styling for the Markdown preview with added padding and specific whitespace handling.

- **Bug Fixes**
	- Fixed issues with rendering code blocks related to KaTeX.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->