### PR TITLE
Fix Dockerfile path in docker publish YAML 

### DIFF
--- a/.github/workflows/base-docker-publish.yml
+++ b/.github/workflows/base-docker-publish.yml
@@ -26,4 +26,4 @@ jobs:
       - name: Build & Push Image
         env:
           VERSION: ${{ inputs.version }}
-        run: docker buildx build --platform linux/amd64,linux/arm64 -t yorkieteam/codepair:$VERSION --push ./backend
+        run: docker buildx build --platform linux/amd64,linux/arm64 -t yorkieteam/codepair:$VERSION --push .

--- a/.github/workflows/docker-publish-latest.yaml
+++ b/.github/workflows/docker-publish-latest.yaml
@@ -5,6 +5,7 @@ on:
       - main
     paths:
       - ".github/workflows/docker-publish-latest.yaml"
+      - "backend/**"
       - "Dockerfile"
 jobs:
   call-base-docker-publish:

--- a/.github/workflows/docker-publish-latest.yaml
+++ b/.github/workflows/docker-publish-latest.yaml
@@ -5,7 +5,7 @@ on:
       - main
     paths:
       - ".github/workflows/docker-publish-latest.yaml"
-      - "backend/**"
+      - "Dockerfile"
 jobs:
   call-base-docker-publish:
     uses: ./.github/workflows/base-docker-publish.yml


### PR DESCRIPTION
#### What this PR does / why we need it?
This PR fixes the Dockerfile path in the docker publish YAML file. The Dockerfile was previously located in the backend folder and has now been moved to the root of the repository. This change ensures that the build process can correctly locate the Dockerfile.

#### Any background context you want to provide?
The relocation of the Dockerfile necessitated updates to the configuration files that reference its path. This change is important for maintaining the integrity of the build and deployment processes within our CI/CD pipeline.

#### What are the relevant tickets?
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

### Checklist
- [x] Added relevant tests or not required
- [x] Didn't break anything

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
	- Updated workflow configurations for Docker publishing to streamline triggers and improve efficiency.
	- Changed the context for Docker build commands to enhance clarity and reduce complexity. 
	- Modified workflow triggers to activate only on changes to the `Dockerfile`, optimizing the deployment process.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->