### PR TITLE
Fix cursor movement logic during Snapshot Event

### DIFF
--- a/frontend/src/utils/yorkie/yorkieSync.ts
+++ b/frontend/src/utils/yorkie/yorkieSync.ts
@@ -53,10 +53,22 @@ class YorkieSyncPluginValue implements cmView.PluginValue {
 
 			// The text is replaced to snapshot and must be re-synced.
 			const text = this._doc.getRoot().content;
-			view.dispatch({
+			const selection = this._doc.getMyPresence().selection;
+			const transactionSpec: cmState.TransactionSpec = {
 				changes: { from: 0, to: view.state.doc.length, insert: text.toString() },
 				annotations: [cmState.Transaction.remote.of(true)],
-			});
+			};
+
+			if (selection) {
+				// Restore the cursor position when the text is replaced.
+				const cursor = text.posRangeToIndexRange(selection);
+				transactionSpec["selection"] = {
+					anchor: cursor[0],
+					head: cursor[1],
+				};
+			}
+
+			view.dispatch(transactionSpec);
 		});
 
 		this._doc.update((root) => {


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

**What this PR does / why we need it**:
This PR modifies the cursor movement logic triggered during a Snapshot Event. Previously, when a Snapshot Event occurred, the entire content was replaced, causing the cursor to jump to the top. This update ensures that the cursor remains in its intended position after the Snapshot Event.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

**Special notes for your reviewer**:
The previous implementation negatively impacted the user experience by causing disruption in text editing, as users would lose their cursor position unexpectedly. This change aims to improve usability by maintaining the cursor’s position during content updates.

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```

**Additional documentation**:

<!--
This section can be blank if this pull request does not require a release note.

Please use the following format for linking documentation:
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```

**Checklist**:
- [x] Added relevant tests or not required
- [x] Didn't break anything


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Improved document synchronization with the CodeMirror editor, enhancing selection handling during updates.
	- Added functionality to restore cursor position after document content changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->