### PR TITLE
Change desktop publishing options to upload artifacts

### DIFF
--- a/.github/workflows/desktop-publish.yml
+++ b/.github/workflows/desktop-publish.yml
@@ -32,18 +32,6 @@ jobs:
 
       - name: Build and publish
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           pnpm run release
-
-      - name: Upload Release Assets
-        uses: softprops/action-gh-release@v2
-        with:
-          files: |
-            ./release/**/*.exe
-            ./release/**/*.dmg
-            ./release/**/*.AppImage
-            ./release/**/*.yml
-            ./release/latest*.yml
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/desktop/package.json
+++ b/desktop/package.json
@@ -28,10 +28,11 @@
 	},
 	"build": {
 		"publish": {
-			"provider": "github"
+			"provider": "github",
+			"releaseType": "release"
 		},
 		"appId": "com.yorkie-team.codepair",
-		"productName": "codepair",
+		"productName": "CodePair",
 		"icon": "build/icon.png",
 		"files": [
 			"dist/**/*",


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

**What this PR does / why we need it**:

As the `electron-builder` only detects releases which the release type is `draft`, the github actions don't upload artifacts. So this PR changes the detection draft type to `release` and deletes redundant uploading actions.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #422 

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```

**Additional documentation**:

<!--
This section can be blank if this pull request does not require a release note.

Please use the following format for linking documentation:
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```

**Checklist**:
- [x] Added relevant tests or not required
- [x] Didn't break anything


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Added a `releaseType` property to enhance build configurations.
	- Updated product name to "CodePair" for improved identification.

- **Bug Fixes**
	- Removed the "Upload Release Assets" step to streamline the release workflow.

- **Chores**
	- Updated environment variable from `GITHUB_TOKEN` to `GH_TOKEN` in the build process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->