### PR TITLE
Change displaying updated at field in `DocumentCard`

### DIFF
--- a/frontend/src/components/cards/DocumentCard.tsx
+++ b/frontend/src/components/cards/DocumentCard.tsx
@@ -58,7 +58,7 @@ function DocumentCard(props: DocumentCardProps) {
 							}}
 						/>
 						<Typography variant="body2" color="text.secondary" noWrap>
-							{moment(document.updatedAt).format("D MMM YYYY")}
+							{moment(document.updatedAt).fromNow()}
 						</Typography>
 					</Stack>
 					{/* TODO(devleejb): When the fetching presemces from yorkie is implemented, uncomment the following code */}


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

**What this PR does / why we need it**:

- Change displaying updated at field in `DocumentCard`
    - Date -> `fromNow` string
    - ex) `a few seconds ago`

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```

**Additional documentation**:

<!--
This section can be blank if this pull request does not require a release note.

Please use the following format for linking documentation:
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```

**Checklist**:
- [x] Added relevant tests or not required
- [x] Didn't break anything


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Updated the display of the document's last updated date to show relative time (e.g., "3 days ago").
  
- **Bug Fixes**
	- Improved clarity in the document update timestamp presentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->