### PR TITLE
Add wrapcheck ignore rules for Echo internal packages

### DIFF
--- a/backend-go/.golangci.yml
+++ b/backend-go/.golangci.yml
@@ -30,3 +30,4 @@ linters-settings:
   wrapcheck:
     ignoreSigRegexps:
       - github.com/yorkie-team/codepair/backend # Ignore all methods in internal package
+      - github.com/labstack/echo/v4 # Ignore all methods in echo package


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

**What this PR does / why we need it**:
This PR adds `wrapcheck.ignoreSigRegexps` to exclude errors from Echo and internal packages.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```

**Additional documentation**:

<!--
This section can be blank if this pull request does not require a release note.

Please use the following format for linking documentation:
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```

**Checklist**:
- [x] Added relevant tests or not required
- [x] Didn't break anything


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Updated internal linter configuration to ignore additional method signature warnings, reducing development noise.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->