### PR TITLE
Bump Go version to 1.23 in `go.mod`

### DIFF
--- a/.github/workflows/ci_backend_go.yaml
+++ b/.github/workflows/ci_backend_go.yaml
@@ -26,7 +26,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
-          go-version: "1.21"
+          go-version: "1.23"
 
       - name: Install Tools
         run: make tools

--- a/backend-go/go.mod
+++ b/backend-go/go.mod
@@ -1,6 +1,6 @@
 module github.com/yorkie-team/codepair/backend
 
-go 1.21
+go 1.23
 
 require (
 	github.com/go-playground/validator/v10 v10.24.0


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

**What this PR does / why we need it**:
This PR bumps Go version to 1.23 in `go.mod`.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Related to https://github.com/yorkie-team/yorkie/issues/1140

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```

**Additional documentation**:

<!--
This section can be blank if this pull request does not require a release note.

Please use the following format for linking documentation:
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```

**Checklist**:
- [ ] Added relevant tests or not required
- [ ] Didn't break anything


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Upgraded the backend runtime to Go version 1.23 to ensure improved environment consistency and compatibility during integration and testing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->