### PR TITLE
Implement new DocumentHeader design based on Figma specifications

### DIFF
--- a/frontend/src/components/editor/DocumentView.tsx
+++ b/frontend/src/components/editor/DocumentView.tsx
@@ -1,17 +1,26 @@
-import { Backdrop, Box, CircularProgress, Paper } from "@mui/material";
+import { useState } from "react";
+import { Backdrop, Box, CircularProgress, Paper, IconButton, Button } from "@mui/material";
 import { useWindowWidth } from "@react-hook/window-size";
 import { useSelector } from "react-redux";
 import Resizable from "react-resizable-layout";
 import { ScrollSync, ScrollSyncPane } from "react-scroll-sync";
 import { EditorModeType, selectEditor } from "../../store/editorSlice";
+import { selectConfig } from "../../store/configSlice";
 import Editor from "./Editor";
 import Preview from "./Preview";
-import { selectConfig } from "../../store/configSlice";
+import {
+	Visibility as VisibilityIcon,
+	VerticalSplit as VerticalSplitIcon,
+	Subject as SubjectIcon,
+	ChevronRight as ChevronRightIcon,
+	ChevronLeft as ChevronLeftIcon,
+} from "@mui/icons-material";
 
 function DocumentView() {
 	const editorStore = useSelector(selectEditor);
 	const windowWidth = useWindowWidth();
 	const configStore = useSelector(selectConfig);
+	const [open, setOpen] = useState(false);
 
 	if (!editorStore.doc || !editorStore.client)
 		return (
@@ -86,6 +95,73 @@ function DocumentView() {
 					<Preview />
 				</Box>
 			)}
+
+			{/* Floating Menu */}
+			<Box
+				sx={{
+					position: "fixed",
+					top: "50%",
+					right: open ? 16 : 0, // 펼쳐지면 16px 이동
+					transform: "translateY(-50%)",
+					display: "flex",
+					alignItems: "center",
+				}}
+			>
+				{/* 토글 버튼 */}
+				<IconButton
+					onClick={() => setOpen(!open)}
+					sx={{
+						width: 40,
+						height: 40,
+						borderRadius: "8px 0 0 8px",
+						backgroundColor: "#fff",
+						color: "#000",
+						boxShadow: 3,
+						"&:hover": { backgroundColor: "#f5f5f5" },
+					}}
+				>
+					{open ? <ChevronRightIcon /> : <ChevronLeftIcon />}
+				</IconButton>
+
+				{/* 버튼 메뉴 (open 상태일 때만) */}
+				{open && (
+					<Paper
+						elevation={4}
+						sx={{
+							display: "flex",
+							flexDirection: "column",
+							gap: 2,
+							padding: 1.5,
+							backgroundColor: "#fff",
+						}}
+					>
+						<Button
+							sx={{
+								display: "flex",
+								flexDirection: "column",
+								justifyContent: "center",
+							}}
+						>
+							<VisibilityIcon sx={{ color: "#000", width: "28px", height: "28px" }} />
+							<span style={{ color: "#000" }}>view</span>
+						</Button>
+						<Button
+							sx={{ display: "flex", flexDirection: "column", alignItems: "center" }}
+						>
+							<VerticalSplitIcon
+								sx={{ color: "#000 ", width: "28px", height: "28px" }}
+							/>
+							<span style={{ color: "#000" }}>edit / view</span>
+						</Button>
+						<Button
+							sx={{ display: "flex", flexDirection: "column", alignItems: "center" }}
+						>
+							<SubjectIcon sx={{ color: "#000 ", width: "28px", height: "28px" }} />
+							<span style={{ color: "#000" }}>edit</span>
+						</Button>
+					</Paper>
+				)}
+			</Box>
 		</>
 	);
 }

--- a/frontend/src/components/editor/DocumentView.tsx
+++ b/frontend/src/components/editor/DocumentView.tsx
@@ -1,21 +1,21 @@
-import { useState } from "react";
-import { Backdrop, Box, CircularProgress, Paper, IconButton, Button } from "@mui/material";
+import {
+	ArrowLeft as ArrowLeftIcon,
+	ArrowRight as ArrowRightIcon,
+	Subject as SubjectIcon,
+	VerticalSplit as VerticalSplitIcon,
+	Visibility as VisibilityIcon,
+} from "@mui/icons-material";
+import { Backdrop, Box, Button, CircularProgress, IconButton, Paper } from "@mui/material";
 import { useWindowWidth } from "@react-hook/window-size";
+import { useState } from "react";
 import { useDispatch, useSelector } from "react-redux";
 import Resizable from "react-resizable-layout";
 import { ScrollSync, ScrollSyncPane } from "react-scroll-sync";
-import { EditorModeType, selectEditor, setMode } from "../../store/editorSlice";
 import { selectConfig } from "../../store/configSlice";
+import { EditorModeType, selectEditor, setMode } from "../../store/editorSlice";
+import { ShareRole } from "../../utils/share";
 import Editor from "./Editor";
 import Preview from "./Preview";
-import {
-	Visibility as VisibilityIcon,
-	VerticalSplit as VerticalSplitIcon,
-	Subject as SubjectIcon,
-	ChevronRight as ChevronRightIcon,
-	ChevronLeft as ChevronLeftIcon,
-} from "@mui/icons-material";
-import { ShareRole } from "../../utils/share";
 
 function DocumentView() {
 	const dispatch = useDispatch();
@@ -125,7 +125,7 @@ function DocumentView() {
 						"&:hover": { backgroundColor: "#f5f5f5" },
 					}}
 				>
-					{open ? <ChevronRightIcon /> : <ChevronLeftIcon />}
+					{open ? <ArrowRightIcon /> : <ArrowLeftIcon />}
 				</IconButton>
 
 				{open && editorStore.shareRole !== ShareRole.READ && (

--- a/frontend/src/components/editor/DocumentView.tsx
+++ b/frontend/src/components/editor/DocumentView.tsx
@@ -147,24 +147,90 @@ function DocumentView() {
 								justifyContent: "center",
 							}}
 						>
-							<VisibilityIcon sx={{ color: "#000", width: "28px", height: "28px" }} />
-							<span style={{ color: "#000" }}>view</span>
+							<VisibilityIcon
+								sx={{
+									color:
+										editorStore.mode === EditorModeType.READ
+											? "#1976d2"
+											: "#000",
+									width: "28px",
+									height: "28px",
+								}}
+							/>
+							<span
+								style={{
+									color:
+										editorStore.mode === EditorModeType.READ
+											? "#1976d2"
+											: "#000",
+									fontSize: "10px",
+									fontWeight: "600",
+								}}
+							>
+								view
+							</span>
 						</Button>
 						<Button
 							onClick={() => handleChangeMode(EditorModeType.BOTH)}
-							sx={{ display: "flex", flexDirection: "column", alignItems: "center" }}
+							sx={{
+								display: "flex",
+								flexDirection: "column",
+								alignItems: "center",
+							}}
 						>
 							<VerticalSplitIcon
-								sx={{ color: "#000 ", width: "28px", height: "28px" }}
+								sx={{
+									color:
+										editorStore.mode === EditorModeType.BOTH
+											? "#1976d2"
+											: "#000",
+									width: "28px",
+									height: "28px",
+								}}
 							/>
-							<span style={{ color: "#000" }}>edit / view</span>
+							<span
+								style={{
+									color:
+										editorStore.mode === EditorModeType.BOTH
+											? "#1976d2"
+											: "#000",
+									fontSize: "10px",
+									fontWeight: "600",
+								}}
+							>
+								edit / view
+							</span>
 						</Button>
 						<Button
 							onClick={() => handleChangeMode(EditorModeType.EDIT)}
-							sx={{ display: "flex", flexDirection: "column", alignItems: "center" }}
+							sx={{
+								display: "flex",
+								flexDirection: "column",
+								alignItems: "center",
+							}}
 						>
-							<SubjectIcon sx={{ color: "#000 ", width: "28px", height: "28px" }} />
-							<span style={{ color: "#000" }}>edit</span>
+							<SubjectIcon
+								sx={{
+									color:
+										editorStore.mode === EditorModeType.EDIT
+											? "#1976d2"
+											: "#000",
+									width: "28px",
+									height: "28px",
+								}}
+							/>
+							<span
+								style={{
+									color:
+										editorStore.mode === EditorModeType.EDIT
+											? "#1976d2"
+											: "#000",
+									fontSize: "10px",
+									fontWeight: "600",
+								}}
+							>
+								edit
+							</span>
 						</Button>
 					</Paper>
 				)}

--- a/frontend/src/components/editor/DocumentView.tsx
+++ b/frontend/src/components/editor/DocumentView.tsx
@@ -1,10 +1,10 @@
 import { useState } from "react";
 import { Backdrop, Box, CircularProgress, Paper, IconButton, Button } from "@mui/material";
 import { useWindowWidth } from "@react-hook/window-size";
-import { useSelector } from "react-redux";
+import { useDispatch, useSelector } from "react-redux";
 import Resizable from "react-resizable-layout";
 import { ScrollSync, ScrollSyncPane } from "react-scroll-sync";
-import { EditorModeType, selectEditor } from "../../store/editorSlice";
+import { EditorModeType, selectEditor, setMode } from "../../store/editorSlice";
 import { selectConfig } from "../../store/configSlice";
 import Editor from "./Editor";
 import Preview from "./Preview";
@@ -15,12 +15,19 @@ import {
 	ChevronRight as ChevronRightIcon,
 	ChevronLeft as ChevronLeftIcon,
 } from "@mui/icons-material";
+import { ShareRole } from "../../utils/share";
 
 function DocumentView() {
+	const dispatch = useDispatch();
 	const editorStore = useSelector(selectEditor);
 	const windowWidth = useWindowWidth();
 	const configStore = useSelector(selectConfig);
 	const [open, setOpen] = useState(false);
+
+	const handleChangeMode = (newMode: EditorModeType) => {
+		if (!newMode) return;
+		dispatch(setMode(newMode));
+	};
 
 	if (!editorStore.doc || !editorStore.client)
 		return (
@@ -96,18 +103,16 @@ function DocumentView() {
 				</Box>
 			)}
 
-			{/* Floating Menu */}
 			<Box
 				sx={{
 					position: "fixed",
 					top: "50%",
-					right: open ? 16 : 0, // 펼쳐지면 16px 이동
+					right: open ? 16 : 0,
 					transform: "translateY(-50%)",
 					display: "flex",
 					alignItems: "center",
 				}}
 			>
-				{/* 토글 버튼 */}
 				<IconButton
 					onClick={() => setOpen(!open)}
 					sx={{
@@ -123,8 +128,7 @@ function DocumentView() {
 					{open ? <ChevronRightIcon /> : <ChevronLeftIcon />}
 				</IconButton>
 
-				{/* 버튼 메뉴 (open 상태일 때만) */}
-				{open && (
+				{open && editorStore.shareRole !== ShareRole.READ && (
 					<Paper
 						elevation={4}
 						sx={{
@@ -136,6 +140,7 @@ function DocumentView() {
 						}}
 					>
 						<Button
+							onClick={() => handleChangeMode(EditorModeType.READ)}
 							sx={{
 								display: "flex",
 								flexDirection: "column",
@@ -146,6 +151,7 @@ function DocumentView() {
 							<span style={{ color: "#000" }}>view</span>
 						</Button>
 						<Button
+							onClick={() => handleChangeMode(EditorModeType.BOTH)}
 							sx={{ display: "flex", flexDirection: "column", alignItems: "center" }}
 						>
 							<VerticalSplitIcon
@@ -154,6 +160,7 @@ function DocumentView() {
 							<span style={{ color: "#000" }}>edit / view</span>
 						</Button>
 						<Button
+							onClick={() => handleChangeMode(EditorModeType.EDIT)}
 							sx={{ display: "flex", flexDirection: "column", alignItems: "center" }}
 						>
 							<SubjectIcon sx={{ color: "#000 ", width: "28px", height: "28px" }} />

--- a/frontend/src/components/editor/DocumentView.tsx
+++ b/frontend/src/components/editor/DocumentView.tsx
@@ -1,33 +1,18 @@
-import {
-	ArrowLeft as ArrowLeftIcon,
-	ArrowRight as ArrowRightIcon,
-	Subject as SubjectIcon,
-	VerticalSplit as VerticalSplitIcon,
-	Visibility as VisibilityIcon,
-} from "@mui/icons-material";
-import { Backdrop, Box, Button, CircularProgress, IconButton, Paper } from "@mui/material";
+import { Backdrop, Box, CircularProgress, Paper } from "@mui/material";
 import { useWindowWidth } from "@react-hook/window-size";
-import { useState } from "react";
-import { useDispatch, useSelector } from "react-redux";
+import { useSelector } from "react-redux";
 import Resizable from "react-resizable-layout";
 import { ScrollSync, ScrollSyncPane } from "react-scroll-sync";
 import { selectConfig } from "../../store/configSlice";
-import { EditorModeType, selectEditor, setMode } from "../../store/editorSlice";
-import { ShareRole } from "../../utils/share";
+import { EditorModeType, selectEditor } from "../../store/editorSlice";
 import Editor from "./Editor";
 import Preview from "./Preview";
+import ModeSwitcher from "./ModeSwitcher";
 
 function DocumentView() {
-	const dispatch = useDispatch();
 	const editorStore = useSelector(selectEditor);
 	const windowWidth = useWindowWidth();
 	const configStore = useSelector(selectConfig);
-	const [open, setOpen] = useState(false);
-
-	const handleChangeMode = (newMode: EditorModeType) => {
-		if (!newMode) return;
-		dispatch(setMode(newMode));
-	};
 
 	if (!editorStore.doc || !editorStore.client)
 		return (
@@ -102,139 +87,7 @@ function DocumentView() {
 					<Preview />
 				</Box>
 			)}
-
-			<Box
-				sx={{
-					position: "fixed",
-					top: "50%",
-					right: open ? 16 : 0,
-					transform: "translateY(-50%)",
-					display: "flex",
-					alignItems: "center",
-				}}
-			>
-				<IconButton
-					onClick={() => setOpen(!open)}
-					sx={{
-						width: 40,
-						height: 40,
-						borderRadius: "8px 0 0 8px",
-						backgroundColor: "#fff",
-						color: "#000",
-						boxShadow: 3,
-						"&:hover": { backgroundColor: "#f5f5f5" },
-					}}
-				>
-					{open ? <ArrowRightIcon /> : <ArrowLeftIcon />}
-				</IconButton>
-
-				{open && editorStore.shareRole !== ShareRole.READ && (
-					<Paper
-						elevation={4}
-						sx={{
-							display: "flex",
-							flexDirection: "column",
-							gap: 2,
-							padding: 1.5,
-							backgroundColor: "#fff",
-						}}
-					>
-						<Button
-							onClick={() => handleChangeMode(EditorModeType.READ)}
-							sx={{
-								display: "flex",
-								flexDirection: "column",
-								justifyContent: "center",
-							}}
-						>
-							<VisibilityIcon
-								sx={{
-									color:
-										editorStore.mode === EditorModeType.READ
-											? "#1976d2"
-											: "#000",
-									width: "28px",
-									height: "28px",
-								}}
-							/>
-							<span
-								style={{
-									color:
-										editorStore.mode === EditorModeType.READ
-											? "#1976d2"
-											: "#000",
-									fontSize: "10px",
-									fontWeight: "600",
-								}}
-							>
-								view
-							</span>
-						</Button>
-						<Button
-							onClick={() => handleChangeMode(EditorModeType.BOTH)}
-							sx={{
-								display: "flex",
-								flexDirection: "column",
-								alignItems: "center",
-							}}
-						>
-							<VerticalSplitIcon
-								sx={{
-									color:
-										editorStore.mode === EditorModeType.BOTH
-											? "#1976d2"
-											: "#000",
-									width: "28px",
-									height: "28px",
-								}}
-							/>
-							<span
-								style={{
-									color:
-										editorStore.mode === EditorModeType.BOTH
-											? "#1976d2"
-											: "#000",
-									fontSize: "10px",
-									fontWeight: "600",
-								}}
-							>
-								edit / view
-							</span>
-						</Button>
-						<Button
-							onClick={() => handleChangeMode(EditorModeType.EDIT)}
-							sx={{
-								display: "flex",
-								flexDirection: "column",
-								alignItems: "center",
-							}}
-						>
-							<SubjectIcon
-								sx={{
-									color:
-										editorStore.mode === EditorModeType.EDIT
-											? "#1976d2"
-											: "#000",
-									width: "28px",
-									height: "28px",
-								}}
-							/>
-							<span
-								style={{
-									color:
-										editorStore.mode === EditorModeType.EDIT
-											? "#1976d2"
-											: "#000",
-									fontSize: "10px",
-									fontWeight: "600",
-								}}
-							>
-								edit
-							</span>
-						</Button>
-					</Paper>
-				)}
-			</Box>
+			<ModeSwitcher />
 		</>
 	);
 }

--- a/frontend/src/components/editor/ModeSwitcher.tsx
+++ b/frontend/src/components/editor/ModeSwitcher.tsx
@@ -22,6 +22,7 @@ const ModeSwitcher = () => {
 		if (!newMode) return;
 		dispatch(setMode(newMode));
 	};
+	if (editorStore.shareRole === ShareRole.READ) return null;
 	return (
 		<Stack
 			direction="row"
@@ -49,7 +50,7 @@ const ModeSwitcher = () => {
 				</IconButton>
 			</Paper>
 
-			{open && editorStore.shareRole !== ShareRole.READ && (
+			{open && (
 				<Paper
 					elevation={4}
 					sx={{

--- a/frontend/src/components/editor/ModeSwitcher.tsx
+++ b/frontend/src/components/editor/ModeSwitcher.tsx
@@ -33,6 +33,8 @@ const ModeSwitcher = () => {
 		>
 			<IconButton
 				onClick={() => setOpen(!open)}
+				aria-label={open ? "Close mode switcher" : "Open mode switcher"}
+				aria-expanded={open}
 				sx={{
 					width: 32.3,
 					height: 87.35,
@@ -57,87 +59,42 @@ const ModeSwitcher = () => {
 						backgroundColor: "#fff",
 					}}
 				>
-					<Button
-						onClick={() => handleChangeMode(EditorModeType.READ)}
-						sx={{
-							display: "flex",
-							flexDirection: "column",
-							justifyContent: "center",
-						}}
-					>
-						<VisibilityIcon
+					{[
+						{ mode: EditorModeType.READ, icon: VisibilityIcon, label: "view" },
+						{
+							mode: EditorModeType.BOTH,
+							icon: VerticalSplitIcon,
+							label: "edit / view",
+						},
+						{ mode: EditorModeType.EDIT, icon: SubjectIcon, label: "edit" },
+					].map(({ mode, icon: Icon, label }) => (
+						<Button
+							key={mode}
+							onClick={() => handleChangeMode(mode)}
 							sx={{
-								color:
-									editorStore.mode === EditorModeType.READ ? "#1976d2" : "#000",
-								width: "28px",
-								height: "28px",
-							}}
-						/>
-						<span
-							style={{
-								color:
-									editorStore.mode === EditorModeType.READ ? "#1976d2" : "#000",
-								fontSize: "10px",
-								fontWeight: "600",
+								display: "flex",
+								flexDirection: "column",
+								alignItems: "center",
 							}}
 						>
-							view
-						</span>
-					</Button>
-					<Button
-						onClick={() => handleChangeMode(EditorModeType.BOTH)}
-						sx={{
-							display: "flex",
-							flexDirection: "column",
-							alignItems: "center",
-						}}
-					>
-						<VerticalSplitIcon
-							sx={{
-								color:
-									editorStore.mode === EditorModeType.BOTH ? "#1976d2" : "#000",
-								width: "28px",
-								height: "28px",
-							}}
-						/>
-						<span
-							style={{
-								color:
-									editorStore.mode === EditorModeType.BOTH ? "#1976d2" : "#000",
-								fontSize: "10px",
-								fontWeight: "600",
-							}}
-						>
-							edit / view
-						</span>
-					</Button>
-					<Button
-						onClick={() => handleChangeMode(EditorModeType.EDIT)}
-						sx={{
-							display: "flex",
-							flexDirection: "column",
-							alignItems: "center",
-						}}
-					>
-						<SubjectIcon
-							sx={{
-								color:
-									editorStore.mode === EditorModeType.EDIT ? "#1976d2" : "#000",
-								width: "28px",
-								height: "28px",
-							}}
-						/>
-						<span
-							style={{
-								color:
-									editorStore.mode === EditorModeType.EDIT ? "#1976d2" : "#000",
-								fontSize: "10px",
-								fontWeight: "600",
-							}}
-						>
-							edit
-						</span>
-					</Button>
+							<Icon
+								sx={{
+									color: editorStore.mode === mode ? "#1976d2" : "#000",
+									width: "28px",
+									height: "28px",
+								}}
+							/>
+							<span
+								style={{
+									color: editorStore.mode === mode ? "#1976d2" : "#000",
+									fontSize: "10px",
+									fontWeight: "600",
+								}}
+							>
+								{label}
+							</span>
+						</Button>
+					))}
 				</Paper>
 			)}
 		</Box>

--- a/frontend/src/components/editor/ModeSwitcher.tsx
+++ b/frontend/src/components/editor/ModeSwitcher.tsx
@@ -5,7 +5,7 @@ import {
 	VerticalSplit as VerticalSplitIcon,
 	Visibility as VisibilityIcon,
 } from "@mui/icons-material";
-import { Button, IconButton, Paper, Stack, Typography } from "@mui/material";
+import { Box, Button, IconButton, Stack, Typography } from "@mui/material";
 import { useState } from "react";
 import { useDispatch, useSelector } from "react-redux";
 import { EditorModeType, selectEditor, setMode } from "../../store/editorSlice";
@@ -34,7 +34,7 @@ const ModeSwitcher = () => {
 				transform: "translateY(-50%)",
 			}}
 		>
-			<Paper elevation={4}>
+			<Box>
 				<IconButton
 					onClick={() => setOpen(!open)}
 					aria-label={open ? "Close mode switcher" : "Open mode switcher"}
@@ -43,21 +43,23 @@ const ModeSwitcher = () => {
 						width: 32.3,
 						height: 87.35,
 						borderRadius: "8px 0 0 8px",
-						boxShadow: open ? "-3px 0px 5px -2px rgba(0, 0, 0, 0.2)" : 3,
+						boxShadow: "-3px 0px 5px -2px rgba(0, 0, 0, 0.2)",
+						backgroundColor: `${themeMode === "dark" ? "#121212" : "#fff"}`,
 					}}
 				>
 					{open ? <ArrowRightIcon /> : <ArrowLeftIcon />}
 				</IconButton>
-			</Paper>
+			</Box>
 
 			{open && (
-				<Paper
-					elevation={4}
+				<Box
 					sx={{
 						display: "flex",
 						flexDirection: "column",
 						gap: 2,
 						padding: 1.5,
+						backgroundColor: themeMode === "dark" ? "#121212" : "#fff",
+						boxShadow: "-3px 0px 5px -2px rgba(0, 0, 0, 0.2)",
 					}}
 				>
 					{[
@@ -103,7 +105,7 @@ const ModeSwitcher = () => {
 							</Button>
 						);
 					})}
-				</Paper>
+				</Box>
 			)}
 		</Stack>
 	);

--- a/frontend/src/components/editor/ModeSwitcher.tsx
+++ b/frontend/src/components/editor/ModeSwitcher.tsx
@@ -68,38 +68,41 @@ const ModeSwitcher = () => {
 							label: "edit / view",
 						},
 						{ mode: EditorModeType.EDIT, icon: SubjectIcon, label: "edit" },
-					].map(({ mode, icon: Icon, label }) => (
-						<Button key={mode} onClick={() => handleChangeMode(mode)}>
-							<Stack direction="column" alignItems="center" spacing={0.5}>
-								<Icon
-									sx={{
-										color:
-											editorStore.mode === mode
-												? "#1976d2"
-												: themeMode === "dark"
-													? "#fff"
-													: "#000",
-										width: "28px",
-										height: "28px",
-									}}
-								/>
-								<Typography
-									style={{
-										color:
-											editorStore.mode === mode
-												? "#1976d2"
-												: themeMode === "dark"
-													? "#fff"
-													: "#000",
-										fontSize: "10px",
-										fontWeight: "600",
-									}}
-								>
-									{label}
-								</Typography>
-							</Stack>
-						</Button>
-					))}
+					].map(({ mode, icon: Icon, label }) => {
+						const isSelected = editorStore.mode === mode;
+						const highlightColor = isSelected
+							? "#1976d2"
+							: themeMode === "dark"
+								? "#fff"
+								: "#000";
+						return (
+							<Button
+								key={mode}
+								onClick={() => handleChangeMode(mode)}
+								aria-pressed={editorStore.mode === mode}
+								aria-label={`Switch to ${label} mode`}
+							>
+								<Stack direction="column" alignItems="center" spacing={0.5}>
+									<Icon
+										sx={{
+											color: highlightColor,
+											width: "28px",
+											height: "28px",
+										}}
+									/>
+									<Typography
+										style={{
+											color: highlightColor,
+											fontSize: "10px",
+											fontWeight: "600",
+										}}
+									>
+										{label}
+									</Typography>
+								</Stack>
+							</Button>
+						);
+					})}
 				</Paper>
 			)}
 		</Stack>

--- a/frontend/src/components/editor/ModeSwitcher.tsx
+++ b/frontend/src/components/editor/ModeSwitcher.tsx
@@ -5,7 +5,7 @@ import {
 	VerticalSplit as VerticalSplitIcon,
 	Visibility as VisibilityIcon,
 } from "@mui/icons-material";
-import { Box, Button, IconButton, Paper } from "@mui/material";
+import { Box, Button, IconButton, Paper, Typography } from "@mui/material";
 import { useState } from "react";
 import { useDispatch, useSelector } from "react-redux";
 import { EditorModeType, selectEditor, setMode } from "../../store/editorSlice";
@@ -84,7 +84,7 @@ const ModeSwitcher = () => {
 									height: "28px",
 								}}
 							/>
-							<span
+							<Typography
 								style={{
 									color: editorStore.mode === mode ? "#1976d2" : "#000",
 									fontSize: "10px",
@@ -92,7 +92,7 @@ const ModeSwitcher = () => {
 								}}
 							>
 								{label}
-							</span>
+							</Typography>
 						</Button>
 					))}
 				</Paper>

--- a/frontend/src/components/editor/ModeSwitcher.tsx
+++ b/frontend/src/components/editor/ModeSwitcher.tsx
@@ -44,7 +44,7 @@ const ModeSwitcher = () => {
 						height: 87.35,
 						borderRadius: "8px 0 0 8px",
 						boxShadow: "-3px 0px 5px -2px rgba(0, 0, 0, 0.2)",
-						backgroundColor: `${themeMode === "dark" ? "#121212" : "#fff"}`,
+						backgroundColor: `${themeMode === "dark" ? "#292A30" : "#fff"}`,
 					}}
 				>
 					{open ? <ArrowRightIcon /> : <ArrowLeftIcon />}
@@ -58,7 +58,7 @@ const ModeSwitcher = () => {
 						flexDirection: "column",
 						gap: 2,
 						padding: 1.5,
-						backgroundColor: themeMode === "dark" ? "#121212" : "#fff",
+						backgroundColor: themeMode === "dark" ? "#292A30" : "#fff",
 						boxShadow: "-3px 0px 5px -2px rgba(0, 0, 0, 0.2)",
 					}}
 				>

--- a/frontend/src/components/editor/ModeSwitcher.tsx
+++ b/frontend/src/components/editor/ModeSwitcher.tsx
@@ -10,11 +10,13 @@ import { useState } from "react";
 import { useDispatch, useSelector } from "react-redux";
 import { EditorModeType, selectEditor, setMode } from "../../store/editorSlice";
 import { ShareRole } from "../../utils/share";
+import { useCurrentTheme } from "../../hooks/useCurrentTheme";
 
 const ModeSwitcher = () => {
 	const dispatch = useDispatch();
 	const editorStore = useSelector(selectEditor);
 	const [open, setOpen] = useState(false);
+	const themeMode = useCurrentTheme();
 
 	const handleChangeMode = (newMode: EditorModeType) => {
 		if (!newMode) return;
@@ -70,14 +72,24 @@ const ModeSwitcher = () => {
 							<Stack direction="column" alignItems="center" spacing={0.5}>
 								<Icon
 									sx={{
-										color: editorStore.mode === mode ? "#1976d2" : "#000",
+										color:
+											editorStore.mode === mode
+												? "#1976d2"
+												: themeMode === "dark"
+													? "#fff"
+													: "#000",
 										width: "28px",
 										height: "28px",
 									}}
 								/>
 								<Typography
 									style={{
-										color: editorStore.mode === mode ? "#1976d2" : "#000",
+										color:
+											editorStore.mode === mode
+												? "#1976d2"
+												: themeMode === "dark"
+													? "#fff"
+													: "#000",
 										fontSize: "10px",
 										fontWeight: "600",
 									}}

--- a/frontend/src/components/editor/ModeSwitcher.tsx
+++ b/frontend/src/components/editor/ModeSwitcher.tsx
@@ -25,7 +25,7 @@ const ModeSwitcher = () => {
 			sx={{
 				position: "fixed",
 				top: "50%",
-				right: open ? 16 : 0,
+				right: open ? 1 : 0,
 				transform: "translateY(-50%)",
 				display: "flex",
 				alignItems: "center",

--- a/frontend/src/components/editor/ModeSwitcher.tsx
+++ b/frontend/src/components/editor/ModeSwitcher.tsx
@@ -5,7 +5,7 @@ import {
 	VerticalSplit as VerticalSplitIcon,
 	Visibility as VisibilityIcon,
 } from "@mui/icons-material";
-import { Box, Button, IconButton, Paper, Typography } from "@mui/material";
+import { Button, IconButton, Paper, Stack, Typography } from "@mui/material";
 import { useState } from "react";
 import { useDispatch, useSelector } from "react-redux";
 import { EditorModeType, selectEditor, setMode } from "../../store/editorSlice";
@@ -21,32 +21,31 @@ const ModeSwitcher = () => {
 		dispatch(setMode(newMode));
 	};
 	return (
-		<Box
+		<Stack
+			direction="row"
+			alignItems="center"
 			sx={{
 				position: "fixed",
 				top: "50%",
 				right: open ? 1 : 0,
 				transform: "translateY(-50%)",
-				display: "flex",
-				alignItems: "center",
 			}}
 		>
-			<IconButton
-				onClick={() => setOpen(!open)}
-				aria-label={open ? "Close mode switcher" : "Open mode switcher"}
-				aria-expanded={open}
-				sx={{
-					width: 32.3,
-					height: 87.35,
-					borderRadius: "8px 0 0 8px",
-					backgroundColor: "#fff",
-					color: "#000",
-					boxShadow: open ? "-3px 0px 5px -2px rgba(0, 0, 0, 0.2)" : 3,
-					"&:hover": { backgroundColor: "#f5f5f5" },
-				}}
-			>
-				{open ? <ArrowRightIcon /> : <ArrowLeftIcon />}
-			</IconButton>
+			<Paper elevation={4}>
+				<IconButton
+					onClick={() => setOpen(!open)}
+					aria-label={open ? "Close mode switcher" : "Open mode switcher"}
+					aria-expanded={open}
+					sx={{
+						width: 32.3,
+						height: 87.35,
+						borderRadius: "8px 0 0 8px",
+						boxShadow: open ? "-3px 0px 5px -2px rgba(0, 0, 0, 0.2)" : 3,
+					}}
+				>
+					{open ? <ArrowRightIcon /> : <ArrowLeftIcon />}
+				</IconButton>
+			</Paper>
 
 			{open && editorStore.shareRole !== ShareRole.READ && (
 				<Paper
@@ -56,7 +55,6 @@ const ModeSwitcher = () => {
 						flexDirection: "column",
 						gap: 2,
 						padding: 1.5,
-						backgroundColor: "#fff",
 					}}
 				>
 					{[
@@ -68,36 +66,30 @@ const ModeSwitcher = () => {
 						},
 						{ mode: EditorModeType.EDIT, icon: SubjectIcon, label: "edit" },
 					].map(({ mode, icon: Icon, label }) => (
-						<Button
-							key={mode}
-							onClick={() => handleChangeMode(mode)}
-							sx={{
-								display: "flex",
-								flexDirection: "column",
-								alignItems: "center",
-							}}
-						>
-							<Icon
-								sx={{
-									color: editorStore.mode === mode ? "#1976d2" : "#000",
-									width: "28px",
-									height: "28px",
-								}}
-							/>
-							<Typography
-								style={{
-									color: editorStore.mode === mode ? "#1976d2" : "#000",
-									fontSize: "10px",
-									fontWeight: "600",
-								}}
-							>
-								{label}
-							</Typography>
+						<Button key={mode} onClick={() => handleChangeMode(mode)}>
+							<Stack direction="column" alignItems="center" spacing={0.5}>
+								<Icon
+									sx={{
+										color: editorStore.mode === mode ? "#1976d2" : "#000",
+										width: "28px",
+										height: "28px",
+									}}
+								/>
+								<Typography
+									style={{
+										color: editorStore.mode === mode ? "#1976d2" : "#000",
+										fontSize: "10px",
+										fontWeight: "600",
+									}}
+								>
+									{label}
+								</Typography>
+							</Stack>
 						</Button>
 					))}
 				</Paper>
 			)}
-		</Box>
+		</Stack>
 	);
 };
 

--- a/frontend/src/components/editor/ModeSwitcher.tsx
+++ b/frontend/src/components/editor/ModeSwitcher.tsx
@@ -1,0 +1,147 @@
+import {
+	ArrowLeft as ArrowLeftIcon,
+	ArrowRight as ArrowRightIcon,
+	Subject as SubjectIcon,
+	VerticalSplit as VerticalSplitIcon,
+	Visibility as VisibilityIcon,
+} from "@mui/icons-material";
+import { Box, Button, IconButton, Paper } from "@mui/material";
+import { useState } from "react";
+import { useDispatch, useSelector } from "react-redux";
+import { EditorModeType, selectEditor, setMode } from "../../store/editorSlice";
+import { ShareRole } from "../../utils/share";
+
+const ModeSwitcher = () => {
+	const dispatch = useDispatch();
+	const editorStore = useSelector(selectEditor);
+	const [open, setOpen] = useState(false);
+
+	const handleChangeMode = (newMode: EditorModeType) => {
+		if (!newMode) return;
+		dispatch(setMode(newMode));
+	};
+	return (
+		<Box
+			sx={{
+				position: "fixed",
+				top: "50%",
+				right: open ? 16 : 0,
+				transform: "translateY(-50%)",
+				display: "flex",
+				alignItems: "center",
+			}}
+		>
+			<IconButton
+				onClick={() => setOpen(!open)}
+				sx={{
+					width: 32.3,
+					height: 87.35,
+					borderRadius: "8px 0 0 8px",
+					backgroundColor: "#fff",
+					color: "#000",
+					boxShadow: open ? "-3px 0px 5px -2px rgba(0, 0, 0, 0.2)" : 3,
+					"&:hover": { backgroundColor: "#f5f5f5" },
+				}}
+			>
+				{open ? <ArrowRightIcon /> : <ArrowLeftIcon />}
+			</IconButton>
+
+			{open && editorStore.shareRole !== ShareRole.READ && (
+				<Paper
+					elevation={4}
+					sx={{
+						display: "flex",
+						flexDirection: "column",
+						gap: 2,
+						padding: 1.5,
+						backgroundColor: "#fff",
+					}}
+				>
+					<Button
+						onClick={() => handleChangeMode(EditorModeType.READ)}
+						sx={{
+							display: "flex",
+							flexDirection: "column",
+							justifyContent: "center",
+						}}
+					>
+						<VisibilityIcon
+							sx={{
+								color:
+									editorStore.mode === EditorModeType.READ ? "#1976d2" : "#000",
+								width: "28px",
+								height: "28px",
+							}}
+						/>
+						<span
+							style={{
+								color:
+									editorStore.mode === EditorModeType.READ ? "#1976d2" : "#000",
+								fontSize: "10px",
+								fontWeight: "600",
+							}}
+						>
+							view
+						</span>
+					</Button>
+					<Button
+						onClick={() => handleChangeMode(EditorModeType.BOTH)}
+						sx={{
+							display: "flex",
+							flexDirection: "column",
+							alignItems: "center",
+						}}
+					>
+						<VerticalSplitIcon
+							sx={{
+								color:
+									editorStore.mode === EditorModeType.BOTH ? "#1976d2" : "#000",
+								width: "28px",
+								height: "28px",
+							}}
+						/>
+						<span
+							style={{
+								color:
+									editorStore.mode === EditorModeType.BOTH ? "#1976d2" : "#000",
+								fontSize: "10px",
+								fontWeight: "600",
+							}}
+						>
+							edit / view
+						</span>
+					</Button>
+					<Button
+						onClick={() => handleChangeMode(EditorModeType.EDIT)}
+						sx={{
+							display: "flex",
+							flexDirection: "column",
+							alignItems: "center",
+						}}
+					>
+						<SubjectIcon
+							sx={{
+								color:
+									editorStore.mode === EditorModeType.EDIT ? "#1976d2" : "#000",
+								width: "28px",
+								height: "28px",
+							}}
+						/>
+						<span
+							style={{
+								color:
+									editorStore.mode === EditorModeType.EDIT ? "#1976d2" : "#000",
+								fontSize: "10px",
+								fontWeight: "600",
+							}}
+						>
+							edit
+						</span>
+					</Button>
+				</Paper>
+			)}
+		</Box>
+	);
+};
+
+export default ModeSwitcher;

--- a/frontend/src/components/editor/ModeSwitcher.tsx
+++ b/frontend/src/components/editor/ModeSwitcher.tsx
@@ -18,11 +18,13 @@ const ModeSwitcher = () => {
 	const [open, setOpen] = useState(false);
 	const themeMode = useCurrentTheme();
 
+	if (editorStore.shareRole === ShareRole.READ) return null;
+
 	const handleChangeMode = (newMode: EditorModeType) => {
 		if (!newMode) return;
 		dispatch(setMode(newMode));
 	};
-	if (editorStore.shareRole === ShareRole.READ) return null;
+
 	return (
 		<Stack
 			direction="row"

--- a/frontend/src/components/headers/DocumentHeader.tsx
+++ b/frontend/src/components/headers/DocumentHeader.tsx
@@ -1,16 +1,10 @@
 import ArrowBackIosNewIcon from "@mui/icons-material/ArrowBackIosNew";
-import EditIcon from "@mui/icons-material/Edit";
 import MoreVertIcon from "@mui/icons-material/MoreVert";
-import VerticalSplitIcon from "@mui/icons-material/VerticalSplit";
-import VisibilityIcon from "@mui/icons-material/Visibility";
 import {
 	AppBar,
 	Grid2 as Grid,
 	IconButton,
-	Paper,
 	Stack,
-	ToggleButton,
-	ToggleButtonGroup,
 	Toolbar,
 	Tooltip,
 	Typography,
@@ -50,11 +44,6 @@ function DocumentHeader() {
 			dispatch(setMode(EditorModeType.READ));
 		}
 	}, [dispatch, editorState.shareRole]);
-
-	const handleChangeMode = (newMode: EditorModeType) => {
-		if (!newMode) return;
-		dispatch(setMode(newMode));
-	};
 
 	const handleToPrevious = () => {
 		navigate(`/${workspaceState.data?.slug}`);
@@ -98,7 +87,7 @@ function DocumentHeader() {
 			<Toolbar>
 				<Grid container spacing={2} width="100%">
 					<Grid size={4}>
-						<Stack direction="row" spacing={1} alignItems="center">
+						<Stack direction="row" spacing={1} alignItems="center" gap={1}>
 							{!editorState.shareRole && (
 								<Tooltip title="Back to Previous Page">
 									<IconButton color="inherit" onClick={handleToPrevious}>
@@ -106,32 +95,17 @@ function DocumentHeader() {
 									</IconButton>
 								</Tooltip>
 							)}
-							<Paper>
-								{editorState.shareRole !== ShareRole.READ && (
-									<ToggleButtonGroup
-										value={editorState.mode}
-										exclusive
-										onChange={(_, newMode) => handleChangeMode(newMode)}
-										size="small"
-									>
-										<ToggleButton value="edit" aria-label="edit">
-											<Tooltip title="Edit Mode">
-												<EditIcon />
-											</Tooltip>
-										</ToggleButton>
-										<ToggleButton value="both" aria-label="both">
-											<Tooltip title="Both Mode">
-												<VerticalSplitIcon />
-											</Tooltip>
-										</ToggleButton>
-										<ToggleButton value="read" aria-label="read">
-											<Tooltip title="Read Mode">
-												<VisibilityIcon />
-											</Tooltip>
-										</ToggleButton>
-									</ToggleButtonGroup>
-								)}
-							</Paper>
+							<span
+								style={{
+									fontFamily: "Roboto",
+									fontWeight: "500",
+									fontSize: "20px",
+									letterSpacing: "0.15px",
+									lineHeight: "160%",
+								}}
+							>
+								{workspaceState.data?.title}
+							</span>
 							<DownloadMenu />
 						</Stack>
 					</Grid>

--- a/frontend/src/components/headers/DocumentHeader.tsx
+++ b/frontend/src/components/headers/DocumentHeader.tsx
@@ -95,17 +95,16 @@ function DocumentHeader() {
 									</IconButton>
 								</Tooltip>
 							)}
-							<span
-								style={{
-									fontFamily: "Roboto",
-									fontWeight: "500",
+							<Typography
+								sx={{
+									fontWeight: 500,
 									fontSize: "20px",
 									letterSpacing: "0.15px",
 									lineHeight: "160%",
 								}}
 							>
 								{workspaceState.data?.title}
-							</span>
+							</Typography>
 							<DownloadMenu />
 						</Stack>
 					</Grid>

--- a/frontend/src/components/headers/DocumentHeader.tsx
+++ b/frontend/src/components/headers/DocumentHeader.tsx
@@ -95,14 +95,7 @@ function DocumentHeader() {
 									</IconButton>
 								</Tooltip>
 							)}
-							<Typography
-								sx={{
-									fontWeight: 500,
-									fontSize: "20px",
-									letterSpacing: "0.15px",
-									lineHeight: "160%",
-								}}
-							>
+							<Typography variant="h6" sx={{ fontWeight: 500 }}>
 								{workspaceState.data?.title}
 							</Typography>
 							<DownloadMenu />


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

**What this PR does / why we need it**:
1. **Remove the view selection button** from the header and **replace it with the workspace name**.
2. Add a **collapse/expand toggle button** in the editor at the center-right position. When expanded, display the editor view selection buttons, allowing users to choose between Edit Mode, Both Mode, and View Mode.
3. The selected mode button colored #1976d2.
4. Create a component named `ModeSwitcher` to handle mode switching functionality(number 2,3).

This video is visually represented!

https://github.com/user-attachments/assets/945ae0b6-c8c3-44ee-ab10-9ef0ebf993aa


**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #378 

**Special notes for your reviewer**:
The `DocumentHeader` component is not exactly the same as in Figma. The download button and more button are not included in the design in Figma. Therefore, while maintaining the original `DocumentHeader` UI and functionality, the mode selection feature has been implemented as a toggle button at the center-right of the editor. Additionally, the workspace title has been placed in the original location of the mode selection UI.

And the toggle button has been implemented in such a way that it does not overlap with the text area when closed, and the styling values follow the Figma specifications.

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
The `DocumentHeader` UI has been updated: 
- The mode selection feature has been moved to a toggle button at the center-right of the editor.
- The workspace title now replaces the previous mode selection UI.
```

**Additional documentation**:

<!--
This section can be blank if this pull request does not require a release note.

Please use the following format for linking documentation:
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs
[Figma Link] : https://www.figma.com/design/OYc1Cr0nvFuBnWZxhscfDk/CodePair?node-id=104-298&t=wkg1T16PacRQXiEM-1
```

**Checklist**:
- [x] Added relevant tests or not required
- [x] Didn't break anything


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced a new `<ModeSwitcher />` component in the document view, allowing users to toggle between different modes (READ, EDIT, BOTH) with clear visual feedback.
- **Bug Fixes**
	- Removed legacy mode selection functionality from the document header for a simplified layout and improved user experience.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->