### PR TITLE
Change config to singleton instance

### DIFF
--- a/backend-go/cmd/codepair/main.go
+++ b/backend-go/cmd/codepair/main.go
@@ -19,12 +19,12 @@ func main() {
 		e.Logger.Fatal(err)
 	}
 
-	conf, err := config.LoadConfig(configPath)
+	err := config.LoadConfig(configPath)
 	if err != nil {
 		e.Logger.Fatal(err)
 	}
 
-	cp, err := server.New(e, conf)
+	cp, err := server.New(e)
 	if err != nil {
 		e.Logger.Fatal(err)
 	}

--- a/backend-go/internal/config/config.go
+++ b/backend-go/internal/config/config.go
@@ -19,15 +19,17 @@ type Config struct {
 	Storage *Storage
 }
 
+var config *Config
+
 // LoadConfig loads configuration settings from a file (if provided) and from environment variables.
 // It returns the populated Config, a status message describing which sources were used, and an error if any.
-func LoadConfig(filePath string) (*Config, error) {
+func LoadConfig(filePath string) error {
 	if err := bindEnvironmentVariables(); err != nil {
-		return nil, err
+		return err
 	}
 
 	if err := readConfigFile(filePath); err != nil {
-		return nil, err
+		return err
 	}
 
 	cfg := &Config{
@@ -39,16 +41,17 @@ func LoadConfig(filePath string) (*Config, error) {
 		Storage: &Storage{},
 	}
 	if err := viper.Unmarshal(cfg); err != nil {
-		return nil, fmt.Errorf("unable to decode configuration into struct: %w", err)
+		return fmt.Errorf("unable to decode configuration into struct: %w", err)
 	}
 
 	cfg.EnsureDefaultValue()
 
 	if err := cfg.validate(); err != nil {
-		return nil, fmt.Errorf("failed to validate config: %w", err)
+		return fmt.Errorf("failed to validate config: %w", err)
 	}
 
-	return cfg, nil
+	config = cfg
+	return nil
 }
 
 // bindEnvironmentVariables binds each configuration key to its corresponding environment variable.
@@ -137,4 +140,14 @@ func (c *Config) validate() error {
 	}
 
 	return nil
+}
+
+func GetConfig() *Config {
+	return config
+}
+
+// SetConfig sets the global config instance.
+// This is primarily used for testing purposes.
+func SetConfig(cfg *Config) {
+	config = cfg
 }

--- a/backend-go/internal/config/config_test.go
+++ b/backend-go/internal/config/config_test.go
@@ -15,8 +15,9 @@ func TestConfigWithEnvVars(t *testing.T) {
 		t.Setenv(key, value)
 	}
 
-	cfg, err := config.LoadConfig("")
+	err := config.LoadConfig("")
 	require.NoError(t, err, "LoadConfig should not fail with valid environment variables")
+	cfg := config.GetConfig()
 
 	// --- Server ---
 	assert.Equal(t, 3002, cfg.Server.Port, "Server.Port should reflect 'SERVER_PORT' env var")
@@ -69,12 +70,13 @@ func TestConfigWithEnvVars(t *testing.T) {
 
 func TestLoadConfigFromFile(t *testing.T) {
 	t.Run("invalid file path", func(t *testing.T) {
-		_, err := config.LoadConfig("invalidPath")
+		err := config.LoadConfig("invalidPath")
 		assert.Error(t, err)
 	})
 
 	t.Run("load config from file", func(t *testing.T) {
-		cfg, err := config.LoadConfig("config-full.test.yaml")
+		err := config.LoadConfig("config-full.test.yaml")
+		cfg := config.GetConfig()
 		require.NoError(t, err, "LoadConfig should not fail with a valid config.yaml file")
 
 		// --- Server ---
@@ -127,7 +129,8 @@ func TestLoadConfigFromFile(t *testing.T) {
 }
 
 func TestConfigWithDefaultValues(t *testing.T) {
-	cfg, err := config.LoadConfig("config-minimal.test.yaml")
+	err := config.LoadConfig("config-minimal.test.yaml")
+	cfg := config.GetConfig()
 	require.NoError(t, err, "LoadConfig should succeed with a minimal config file")
 
 	// --- Server defaults ---

--- a/backend-go/internal/server/server.go
+++ b/backend-go/internal/server/server.go
@@ -23,7 +23,8 @@ type CodePair struct {
 }
 
 // New creates a new CodePair server.
-func New(e *echo.Echo, conf *config.Config) (*CodePair, error) {
+func New(e *echo.Echo) (*CodePair, error) {
+	conf := config.GetConfig()
 	e.HTTPErrorHandler = middleware.HTTPErrorHandler
 
 	db, err := mongodb.Dial(conf.Mongo, e.Logger)

--- a/backend-go/test/helper/helper.go
+++ b/backend-go/test/helper/helper.go
@@ -41,18 +41,21 @@ func NewTestConfig(testName string) *config.Config {
 	conf.Mongo.ConnectionURI = "mongodb://localhost:27017"
 	conf.Mongo.DatabaseName = fmt.Sprintf("test-codepair-%s-%s", testName, bson.NewObjectID().Hex())
 	conf.OAuth.FrontendBaseURL = "http://frontend-url"
+	config.SetConfig(conf)
 	return conf
 }
 
 // SetupTestServer creates a new Echo instance and server for integration tests.
 // It starts the server in a background goroutine and returns both the server and the GitHub test server.
-func SetupTestServer(t *testing.T, conf *config.Config) *server.CodePair {
+func SetupTestServer(t *testing.T) *server.CodePair {
 	t.Helper()
 	e := NewTestEcho(t)
 	backendURL := fmt.Sprintf("http://localhost:%d", e.Listener.Addr().(*net.TCPAddr).Port)
 	githubServer, githubConf := NewTestGithubServer(t, backendURL)
+	conf := config.GetConfig()
+
 	conf.OAuth.Github = githubConf
-	codePairServer, err := server.New(e, conf)
+	codePairServer, err := server.New(e)
 	assert.NoError(t, err)
 
 	// Start the server in a background goroutine.

--- a/backend-go/test/integration/auth_test.go
+++ b/backend-go/test/integration/auth_test.go
@@ -23,7 +23,7 @@ func TestRefreshToken(t *testing.T) {
 	conf := helper.NewTestConfig(t.Name())
 	conf.JWT.AccessTokenExpirationTime = accessTokenExpirationTime
 	conf.JWT.RefreshTokenExpirationTime = refreshTokenExpirationTime
-	codePair := helper.SetupTestServer(t, conf)
+	codePair := helper.SetupTestServer(t)
 	getUserURL := codePair.ServerAddr() + getUserPath
 	refreshURL := codePair.ServerAddr() + refreshPath
 

--- a/backend-go/test/integration/users_test.go
+++ b/backend-go/test/integration/users_test.go
@@ -15,7 +15,7 @@ import (
 
 func TestFindUser(t *testing.T) {
 	conf := helper.NewTestConfig(t.Name())
-	codePair := helper.SetupTestServer(t, conf)
+	codePair := helper.SetupTestServer(t)
 	user, access, _ := helper.LoginUserTestGithub(t, t.Name(), codePair.ServerAddr())
 	gen := jwt.NewGenerator(conf.JWT)
 	url := codePair.ServerAddr() + "/users"
@@ -54,8 +54,8 @@ func TestFindUser(t *testing.T) {
 }
 
 func TestChangeUserNickName(t *testing.T) {
-	conf := helper.NewTestConfig(t.Name())
-	codePair := helper.SetupTestServer(t, conf)
+	helper.NewTestConfig(t.Name())
+	codePair := helper.SetupTestServer(t)
 	_, access, _ := helper.LoginUserTestGithub(t, t.Name(), codePair.ServerAddr())
 	url := codePair.ServerAddr() + "/users"
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

**What this PR does / why we need it**:

Change `Config` to a singleton instance to avoid the problem of drilling into the value when needed to read config from an internal layer (service, or repository).

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```

`Config.LoadConfig` no longer returns a `Config` object.
`Config.SetConfig` overrides the `Config` object and is only used in tests.
Instead, use `Config.GetConfig` to get `Config`.


**Additional documentation**:

<!--
This section can be blank if this pull request does not require a release note.

Please use the following format for linking documentation:
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```

**Checklist**:
- [x] Added relevant tests or not required
- [x] Didn't break anything
