### PR TITLE
Fix version pinning prisma and install pnpm from npm

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,8 +2,8 @@
 # Start from the node base image
 FROM node:18.20.7-alpine3.21 AS base
 # Set pnpm installation directory and add it to the PATH
-RUN corepack enable
-RUN corepack use pnpm@9
+
+RUN npm i -g pnpm@9
 
 # Download dependency for Prisma
 RUN apk upgrade --update-cache --available && \
@@ -37,11 +37,11 @@ COPY . /usr/src/app
 WORKDIR /usr/src/app
 RUN sed -i 's/"prepare": "husky install"/"prepare": ""/' ./package.json
 RUN --mount=type=cache,id=pnpm,target=/pnpm/store pnpm install --frozen-lockfile
-RUN pnpx prisma generate --schema=./backend/prisma/schema.prisma
+RUN pnpx prisma@^5.8.1 generate --schema=./backend/prisma/schema.prisma
 RUN pnpm backend build
 RUN pnpm deploy --filter=backend --prod /prod/backend
 WORKDIR /prod/backend
-RUN pnpx prisma generate
+RUN pnpx prisma@^5.8.1 generate
 
 # Stage 3: deploy stage
 FROM base AS backend


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

**What this PR does / why we need it**:

Fix the version of the prisma cli used to build the docker image to use the same version as the server dependencies.

Also change to install pnpm via npm instead of corepack.

![image](https://github.com/user-attachments/assets/1867552f-f003-441c-af35-1ad89156768f)

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```

**Additional documentation**:

<!--
This section can be blank if this pull request does not require a release note.

Please use the following format for linking documentation:
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```

**Checklist**:
- [x] Added relevant tests or not required
- [x] Didn't break anything
