### PR TITLE
Update golangci-lint version to 2

### DIFF
--- a/backend-go/.golangci.yml
+++ b/backend-go/.golangci.yml
@@ -1,16 +1,13 @@
+version: "2"
 run:
-  deadline: 5m
-  skip-dirs:
-    - api/codepair/v1/models # Auto-generated code
+  timeout: 5m
 
 linters:
   enable:
     - errcheck
-    - goimports
     - govet
     - goconst
     - gocyclo
-    - gofmt
     - revive
     - goprintffuncname
     - gosec
@@ -19,15 +16,30 @@ linters:
     - nakedret
     - wrapcheck
   disable:
-    - gosimple
     - staticcheck
-    - structcheck
     - unused
-
-linters-settings:
-  goimports:
-    local-prefixes: github.com/yorkie-team/codepair
-  wrapcheck:
-    ignorePackageGlobs:
+  exclusions:
+    paths:
+      - api/codepair/v1/models # Auto-generated code
+  settings:
+    wrapcheck:
+      ignore-package-globs:
       - github.com/yorkie-team/codepair/backend # Ignore all methods in internal package
       - github.com/labstack/echo/v4 # Ignore all methods in echo package
+    revive:
+      rules:
+        - name: exported
+          disabled: true
+        - name: package-comments
+          disabled: true
+
+
+formatters:
+  enable:
+    - gofmt
+    - goimports
+  settings:
+    goimports:
+      local-prefixes:
+        - github.com/yorkie-team/codepair
+

--- a/backend-go/Makefile
+++ b/backend-go/Makefile
@@ -3,7 +3,7 @@ CODEPAIR_VERSION := 0.2.0
 default: help
 
 tools: ## install tools for developing codepair
-	go install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.55.1
+	go install github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.1.6
 
 build: ## builds an executable that runs in the current environment
 	go build -o ./bin/codepair ./cmd/codepair


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

**What this PR does / why we need it**:

`golangci-lint@v1` is not linting properly on macOS for some reason. (it works on other linux distro with no problem)

so I suggest update `golangci-lint` to v2.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```

**Additional documentation**:

<!--
This section can be blank if this pull request does not require a release note.

Please use the following format for linking documentation:
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```

**Checklist**:
- [ ] Added relevant tests or not required
- [ ] Didn't break anything
