### PR TITLE
Adjust deprecated fields(pprof flag & top-level version)

### DIFF
--- a/backend-go/docker/docker-compose.yml
+++ b/backend-go/docker/docker-compose.yml
@@ -1,5 +1,3 @@
-version: "3.8"
-
 services:
   mongo:
     build:

--- a/backend/docker/docker-compose-full.yml
+++ b/backend/docker/docker-compose-full.yml
@@ -41,7 +41,7 @@ services:
 
     yorkie:
         image: "yorkieteam/yorkie:0.5.7"
-        command: ["server", "--enable-pprof"]
+        command: ["server", "--pprof-enabled"]
         restart: always
         ports:
             - "8080:8080"

--- a/backend/docker/docker-compose-full.yml
+++ b/backend/docker/docker-compose-full.yml
@@ -1,5 +1,3 @@
-version: "3.8"
-
 services:
     codepair-backend:
         build:
@@ -40,7 +38,7 @@ services:
         restart: unless-stopped
 
     yorkie:
-        image: "yorkieteam/yorkie:0.5.7"
+        image: "yorkieteam/yorkie:latest"
         command: ["server", "--pprof-enabled"]
         restart: always
         ports:

--- a/backend/docker/docker-compose.yml
+++ b/backend/docker/docker-compose.yml
@@ -1,8 +1,6 @@
-version: "3.8"
-
 services:
     yorkie:
-        image: "yorkieteam/yorkie:0.5.7"
+        image: "yorkieteam/yorkie:latest"
         command: ["server", "--pprof-enabled"]
         restart: always
         ports:

--- a/backend/docker/docker-compose.yml
+++ b/backend/docker/docker-compose.yml
@@ -3,7 +3,7 @@ version: "3.8"
 services:
     yorkie:
         image: "yorkieteam/yorkie:0.5.7"
-        command: ["server", "--enable-pprof"]
+        command: ["server", "--pprof-enabled"]
         restart: always
         ports:
             - "8080:8080"

--- a/backend/docker/mongodb_replica/docker-compose.yml
+++ b/backend/docker/mongodb_replica/docker-compose.yml
@@ -1,5 +1,3 @@
-version: "3.8"
-
 services:
     # This config is for MongoDB v4
     # It's a Replica Set (required for Prisma Client)


### PR DESCRIPTION
**What this PR does / why we need it**:
- Update the `--enable-pprof` flag has been replaced with `--pprof-enabled` the [Yorkie server](https://github.com/yorkie-team/yorkie/pull/1364)
- Remove deprecated `top-level` version ([compose-spec](https://github.com/compose-spec/compose-spec/tree/main))
- remote `yorkie:latest` docker image

**Which issue(s) this PR fixes**:
Fixes #495 

**Does this PR introduce a user-facing change?**:
"NONE"

**Checklist**:
- [x] Added relevant tests or not required
- [x] Didn't break anything
