### PR TITLE
Add Feature to Show Active Users in Document List

### DIFF
--- a/backend/src/workspace-documents/workspace-documents.service.ts
+++ b/backend/src/workspace-documents/workspace-documents.service.ts
@@ -122,6 +122,8 @@ export class WorkspaceDocumentsService {
 				updatedAt: yorkieDocumentUpdatedAt
 					? moment(yorkieDocumentUpdatedAt).toDate()
 					: doc.updatedAt,
+				root: yorkieDocumentMap.get(doc.yorkieDocumentId)?.root ?? null,
+				presences: yorkieDocumentMap.get(doc.yorkieDocumentId)?.presences ?? null,
 			};
 		});
 

--- a/frontend/src/components/cards/DocumentCard.tsx
+++ b/frontend/src/components/cards/DocumentCard.tsx
@@ -1,4 +1,12 @@
-import { Paper, Stack, Typography } from "@mui/material";
+import {
+	Avatar,
+	AvatarGroup,
+	Paper,
+	Stack,
+	Typography,
+	useMediaQuery,
+	useTheme,
+} from "@mui/material";
 import { Link, useParams } from "react-router-dom";
 import { Document } from "../../hooks/api/types/document.d";
 import moment from "moment";
@@ -11,6 +19,26 @@ interface DocumentCardProps {
 function DocumentCard(props: DocumentCardProps) {
 	const { document } = props;
 	const params = useParams();
+	const theme = useTheme();
+	const isSmallScreen = useMediaQuery(theme.breakpoints.down("lg"));
+
+	const parsePresenceData = (data: {
+		color: string;
+		name: string;
+		cursor: string | null;
+		selection: string | null;
+	}) => {
+		return {
+			color: data.color.replace(/^"|"$/g, ""),
+			name: data.name.replace(/^"|"$/g, ""),
+			cursor: data.cursor,
+			selection: data.selection,
+		};
+	};
+
+	const presenceList = Object.values(document.presences || {}).map((presence) =>
+		parsePresenceData(presence.data)
+	);
 
 	return (
 		<Link
@@ -22,8 +50,11 @@ function DocumentCard(props: DocumentCardProps) {
 			<Paper
 				variant="outlined"
 				sx={{
+					position: "relative",
 					px: 3,
 					py: 2,
+					height: "100%",
+					width: "100%",
 				}}
 			>
 				<Stack direction="row" justifyContent="space-between">
@@ -61,28 +92,25 @@ function DocumentCard(props: DocumentCardProps) {
 							{moment(document.updatedAt).fromNow()}
 						</Typography>
 					</Stack>
-					{/* TODO(devleejb): When the fetching presemces from yorkie is implemented, uncomment the following code */}
-					{/* <AvatarGroup
-						total={6}
-						max={5}
-						sx={{
-							"& .MuiAvatar-root": {
-								width: 32,
-								height: 32,
-							},
-						}}
-					>
-						<Avatar sx={{ width: 32, height: 32 }} alt="Remy Sharp" />
-						<Avatar sx={{ width: 32, height: 32 }} alt="Remy Sharp" />
-						<Avatar sx={{ width: 32, height: 32 }} alt="Remy Sharp" />
-						<Avatar sx={{ width: 32, height: 32 }} alt="Remy Sharp" />
-						<Avatar sx={{ width: 32, height: 32 }} alt="Remy Sharp" />
-						<Avatar sx={{ width: 32, height: 32 }} alt="Remy Sharp" />
-						<Avatar sx={{ width: 32, height: 32 }} alt="Remy Sharp" />
-						<Avatar sx={{ width: 32, height: 32 }} alt="Remy Sharp" />
-						<Avatar sx={{ width: 32, height: 32 }} alt="Remy Sharp" />
-					</AvatarGroup> */}
 				</Stack>
+				<AvatarGroup
+					max={isSmallScreen ? 2 : 4}
+					sx={{
+						position: "absolute",
+						bottom: 16,
+						right: 24,
+						"& .MuiAvatar-root": {
+							width: 38,
+							height: 38,
+						},
+					}}
+				>
+					{presenceList.map((presence, index) => (
+						<Avatar key={index} sx={{ bgcolor: presence.color }} alt={presence.name}>
+							{presence.name[0]}
+						</Avatar>
+					))}
+				</AvatarGroup>
 			</Paper>
 		</Link>
 	);

--- a/frontend/src/hooks/api/types/document.d.ts
+++ b/frontend/src/hooks/api/types/document.d.ts
@@ -8,6 +8,17 @@ export class Document {
 	content?: string;
 	createdAt: Date;
 	updatedAt: Date;
+	presences?: Record<
+		string,
+		{
+			data: {
+				color: string;
+				cursor: string | null;
+				name: string;
+				selection: string | null;
+			};
+		}
+	>;
 }
 
 export class GetDocumentBySharingTokenResponse extends Document {


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

**What this PR does / why we need it**:
This PR updates the document view to display a list of active users by using the presence data obtained from the GetDocuments API. This enhancement allows users to see who is currently active in the document, improving collaboration and awareness among team members.

<img width="1463" height="492" alt="image" src="https://github.com/user-attachments/assets/790af807-bf54-4512-8bcb-98576a072250" />

<img width="1461" height="496" alt="image" src="https://github.com/user-attachments/assets/1a468825-45cb-4bd0-80ad-d580f3ec48c5" />

<img width="606" height="473" alt="image" src="https://github.com/user-attachments/assets/0a060dfa-5f01-4c0a-86b0-8dd60e7fffed" />

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #494 

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```

**Additional documentation**:

<!--
This section can be blank if this pull request does not require a release note.

Please use the following format for linking documentation:
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```

**Checklist**:
- [x] Added relevant tests or not required
- [x] Didn't break anything


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Document cards now display avatars representing active user presences, with avatar colors and initials reflecting each user's presence data.
  * Avatar display adapts responsively, showing up to 2 avatars on small screens and up to 4 on larger screens.

* **Enhancements**
  * Document information now includes additional presence data, providing richer real-time collaboration details.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->