### PR TITLE
Fix editor scroll jumping to top when closing toolbar menu

### DIFF
--- a/frontend/src/components/editor/ToolBar.tsx
+++ b/frontend/src/components/editor/ToolBar.tsx
@@ -45,6 +45,7 @@ function ToolBar({
 				horizontal: "left",
 			}}
 			disableAutoFocus
+			disableRestoreFocus
 			TransitionComponent={Fade}
 			TransitionProps={{ timeout: 300 }}
 		>


### PR DESCRIPTION

**What this PR does / why we need it**:
When using toolbar features and closing the menu, the editor scroll position was unexpectedly jumping to the top due to focus restoration behavior. This change disables the restore focus feature on the toolbar menu to prevent unwanted scroll position changes and maintain the user's current view in the editor.


https://github.com/user-attachments/assets/fd39dda7-677e-4e61-8c6c-e37d352ab334




**Which issue(s) this PR fixes**:
Fixes #503 

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
The editor will no longer scroll to the top when closing the toolbar menu, preserving the user's current scroll position.
```

**Additional documentation**:

<!--
This section can be blank if this pull request does not require a release note.

Please use the following format for linking documentation:
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```

**Checklist**:
- [X] Added relevant tests or not required
- [X] Didn't break anything
