### PR TITLE
Migrate deprecated MUI Grid to the new Grid2 component

### DIFF
--- a/frontend/src/pages/Index.tsx
+++ b/frontend/src/pages/Index.tsx
@@ -1,4 +1,4 @@
-import { Box, Container, Divider, Grid2, Paper, Stack, Typography } from "@mui/material";
+import { Box, Container, Divider, Grid2 as Grid, Paper, Stack, Typography } from "@mui/material";
 import CodePairIcon from "../components/icons/CodePairIcon";
 import { GithubLoginButton } from "react-social-login-buttons";
 
@@ -29,19 +29,19 @@ function Index() {
 							</Typography>
 						</Box>
 						<Stack gap={2}>
-							<Grid2 container spacing={1} alignItems="center">
-								<Grid2 size="grow">
+							<Grid container spacing={1} alignItems="center">
+								<Grid size="grow">
 									<Divider sx={{ width: 1 }} />
-								</Grid2>
-								<Grid2 size="auto">
+								</Grid>
+								<Grid size="auto">
 									<Typography variant="body2" color="text.secondary">
 										Login with
 									</Typography>
-								</Grid2>
-								<Grid2 size="grow">
+								</Grid>
+								<Grid size="grow">
 									<Divider sx={{ width: 1 }} />
-								</Grid2>
-							</Grid2>
+								</Grid>
+							</Grid>
 							{socialLoginList.map(({ SocailLoginComponent, provider }) => (
 								<SocailLoginComponent
 									key={provider}

--- a/frontend/src/pages/Index.tsx
+++ b/frontend/src/pages/Index.tsx
@@ -1,4 +1,4 @@
-import { Box, Container, Divider, Grid, Paper, Stack, Typography } from "@mui/material";
+import { Box, Container, Divider, Grid2, Paper, Stack, Typography } from "@mui/material";
 import CodePairIcon from "../components/icons/CodePairIcon";
 import { GithubLoginButton } from "react-social-login-buttons";
 
@@ -29,19 +29,19 @@ function Index() {
 							</Typography>
 						</Box>
 						<Stack gap={2}>
-							<Grid container spacing={1} alignItems="center">
-								<Grid item xs>
+							<Grid2 container spacing={1} alignItems="center">
+								<Grid2 size="grow">
 									<Divider sx={{ width: 1 }} />
-								</Grid>
-								<Grid item xs="auto">
+								</Grid2>
+								<Grid2 size="auto">
 									<Typography variant="body2" color="text.secondary">
 										Login with
 									</Typography>
-								</Grid>
-								<Grid item xs>
+								</Grid2>
+								<Grid2 size="grow">
 									<Divider sx={{ width: 1 }} />
-								</Grid>
-							</Grid>
+								</Grid2>
+							</Grid2>
 							{socialLoginList.map(({ SocailLoginComponent, provider }) => (
 								<SocailLoginComponent
 									key={provider}

--- a/frontend/src/pages/workspace/Index.tsx
+++ b/frontend/src/pages/workspace/Index.tsx
@@ -9,7 +9,7 @@ import {
 	Box,
 	Button,
 	CircularProgress,
-	Grid2,
+	Grid2 as Grid,
 	Paper,
 	Stack,
 	Tab,
@@ -140,17 +140,17 @@ function WorkspaceIndex() {
 				}
 			>
 				<Box width={1}>
-					<Grid2
+					<Grid
 						container
 						spacing={{ xs: 2, md: 3 }}
 						columns={{ xs: 4, sm: 8, md: 12, lg: 12 }}
 					>
 						{documentList.map((document) => (
-							<Grid2 key={document.id} size={4}>
+							<Grid key={document.id} size={4}>
 								<DocumentCard document={document} />
-							</Grid2>
+							</Grid>
 						))}
-					</Grid2>
+					</Grid>
 				</Box>
 			</InfiniteScroll>
 			<CreateModal


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

**What this PR does / why we need it**:
This file hadn’t been updated like the others and uses the deprecated Grid API causing warnings. So migrated it to Grid2 to match the project’s MUI v6 version.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #507

**Special notes for your reviewer**:
When I opened the issue, I assumed our project was using @mui/material v5, but after checking package.json I saw we’re on v6. I therefore switched the import to Grid2 as per the official docs and updated the props to match v6—without needing to use Unstable_Grid2.

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```

**Additional documentation**:

<!--
This section can be blank if this pull request does not require a release note.

Please use the following format for linking documentation:
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs
- [doc]: <https://v6.mui.com/material-ui/migration/upgrade-to-grid-v2/>
```

**Checklist**:
- [x] Added relevant tests or not required
- [x] Didn't break anything


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Updated layout components to use a newer grid system for improved consistency and maintainability. No visible changes to the user interface or functionality.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->