### PR TITLE
Fix header layout on small screens and AvatarGroup overflow

### DIFF
--- a/frontend/src/components/headers/DocumentHeader.tsx
+++ b/frontend/src/components/headers/DocumentHeader.tsx
@@ -128,7 +128,7 @@ function DocumentHeader() {
 								contentEditable={!isEditingDisabled}
 								sx={{
 									maxWidth: "100%",
-									overflowX: "auto",
+									overflow: "hidden",
 									textOverflow: "ellipsis",
 									":focus": {
 										outline: "none",

--- a/frontend/src/components/headers/DocumentHeader.tsx
+++ b/frontend/src/components/headers/DocumentHeader.tsx
@@ -2,12 +2,13 @@ import ArrowBackIosNewIcon from "@mui/icons-material/ArrowBackIosNew";
 import MoreVertIcon from "@mui/icons-material/MoreVert";
 import {
 	AppBar,
-	Grid2 as Grid,
+	Box,
 	IconButton,
 	Stack,
 	Toolbar,
 	Tooltip,
 	Typography,
+	useMediaQuery,
 } from "@mui/material";
 import { useSnackbar } from "notistack";
 import { useEffect, useState } from "react";
@@ -16,6 +17,7 @@ import { useNavigate } from "react-router-dom";
 import { useUpdateDocumentTitleMutation } from "../../hooks/api/workspaceDocument";
 import { useUserPresence } from "../../hooks/useUserPresence";
 import { selectDocument } from "../../store/documentSlice";
+import { DRAWER_WIDTH } from "../../constants/layout";
 import { EditorModeType, selectEditor, setMode } from "../../store/editorSlice";
 import { selectWorkspace } from "../../store/workspaceSlice";
 import { ShareRole } from "../../utils/share";
@@ -38,6 +40,7 @@ function DocumentHeader() {
 	const isEditingDisabled = Boolean(editorState.shareRole);
 	const { enqueueSnackbar } = useSnackbar();
 	const [moreButtonAnchorEl, setMoreButtonAnchorEl] = useState<HTMLButtonElement | null>(null);
+	const isWideEnough = useMediaQuery(`(min-width:${DRAWER_WIDTH + 512}px)`);
 
 	useEffect(() => {
 		if (editorState.shareRole === ShareRole.READ) {
@@ -85,9 +88,23 @@ function DocumentHeader() {
 	return (
 		<AppBar position="static" sx={{ zIndex: 100 }}>
 			<Toolbar>
-				<Grid container spacing={2} width="100%">
-					<Grid size={4}>
-						<Stack direction="row" spacing={1} alignItems="center" gap={1}>
+				<Stack
+					width="100%"
+					direction="row"
+					justifyContent="space-between"
+					alignItems="center"
+				>
+					<Box>
+						<Stack
+							direction="row"
+							spacing={1}
+							alignItems="center"
+							gap={1}
+							sx={{
+								width: isWideEnough ? DRAWER_WIDTH : undefined,
+								textAlign: "left",
+							}}
+						>
 							{!editorState.shareRole && (
 								<Tooltip title="Back to Previous Page">
 									<IconButton color="inherit" onClick={handleToPrevious}>
@@ -95,32 +112,39 @@ function DocumentHeader() {
 									</IconButton>
 								</Tooltip>
 							)}
-							<Typography variant="h6" sx={{ fontWeight: 500 }}>
-								{workspaceState.data?.title}
-							</Typography>
-							<DownloadMenu />
+							{isWideEnough && (
+								<>
+									<Typography variant="h6" component="span" noWrap>
+										{workspaceState.data?.title}
+									</Typography>
+									<DownloadMenu />
+								</>
+							)}
 						</Stack>
-					</Grid>
-					<Grid size={4}>
+					</Box>
+					<Box sx={{ flexGrow: 1, overflow: "hidden", px: 2 }}>
 						<Stack alignItems="center" justifyContent="center" height="100%">
 							<Typography
 								contentEditable={!isEditingDisabled}
-								suppressContentEditableWarning={true}
 								sx={{
+									maxWidth: "100%",
+									overflowX: "auto",
+									textOverflow: "ellipsis",
 									":focus": {
 										outline: "none",
 										border: "none",
 									},
 								}}
-								onBlur={(e) => handleUpdateDocumentTitle(e)}
-								maxWidth={300}
 								noWrap
+								suppressContentEditableWarning
+								onBlur={handleUpdateDocumentTitle}
 							>
 								{documentStore.data?.title}
 							</Typography>
 						</Stack>
-					</Grid>
-					<Grid size={4}>
+					</Box>
+
+					<Box>
 						<Stack direction="row" justifyContent="end" gap={1}>
 							<UserPresenceList presenceList={presenceList} />
 							{!editorState.shareRole && <ShareButton />}
@@ -133,8 +157,8 @@ function DocumentHeader() {
 								onClose={handleDocumentMenuClose}
 							/>
 						</Stack>
-					</Grid>
-				</Grid>
+					</Box>
+				</Stack>
 			</Toolbar>
 		</AppBar>
 	);

--- a/frontend/src/components/headers/UserPresenceList.tsx
+++ b/frontend/src/components/headers/UserPresenceList.tsx
@@ -62,12 +62,14 @@ function UserPresenceList(props: UserPresenceListProps) {
 	return (
 		<>
 			<AvatarGroup>
-				{presenceList.slice(0, MAX_VISIBLE_AVATARS).map(renderAvatar)}
-				{presenceList.length > MAX_VISIBLE_AVATARS && (
-					<Avatar onClick={handleOpenPopover}>
-						+{presenceList.length - MAX_VISIBLE_AVATARS}
-					</Avatar>
-				)}
+				{presenceList.length > MAX_VISIBLE_AVATARS + 1
+					? [
+							...presenceList.slice(0, MAX_VISIBLE_AVATARS).map(renderAvatar),
+							<Avatar key="more" onClick={handleOpenPopover}>
+								+{presenceList.length - MAX_VISIBLE_AVATARS}
+							</Avatar>,
+						]
+					: presenceList.map(renderAvatar)}
 			</AvatarGroup>
 			<Popover
 				open={popoverOpen}


### PR DESCRIPTION
**What this PR does / why we need it**:

This commit makes two minor frontend adjustments:
- Fixes header layout to render properly on narrow viewports for better mobile support.
- Resolves a minor edge case in AvatarGroup where unexpected rendering occurred when the number of avatars exceeded the visible limit by one.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #514

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```

**Additional documentation**:

![ezgif-5a6ff3f9ba1eae](https://github.com/user-attachments/assets/b7ff5e76-047d-46e9-907d-da71b25fd448)

<img width="593" height="113" alt="스크린샷 2025-07-28 150609" src="https://github.com/user-attachments/assets/44125478-9548-42df-a9cb-b21bb1e79a90" />
before
<img width="625" height="124" alt="스크린샷 2025-07-28 150439" src="https://github.com/user-attachments/assets/02288b71-54a1-4e3e-83f9-fed00619d415" />
after

**Checklist**:
- [x] Added relevant tests or not required
- [x] Didn't break anything



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Improved the layout and responsiveness of the document header for better display across different screen sizes.
  * Enhanced the rendering logic for user avatars to more accurately display the "more" avatar when many users are present.

* **Style**
  * Updated document title styling to support horizontal scrolling and ellipsis for long titles.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->