### PR TITLE
feat add ability to change workspace name

### DIFF
--- a/backend/src/workspaces/dto/update-workspace-title.dto.ts
+++ b/backend/src/workspaces/dto/update-workspace-title.dto.ts
@@ -1,0 +1,8 @@
+import { ApiProperty } from "@nestjs/swagger";
+import { MinLength } from "class-validator";
+
+export class UpdateWorkspaceTitleDto {
+	@ApiProperty({ description: "New title of the workspace", type: String, minLength: 2 })
+	@MinLength(2)
+	title: string;
+}

--- a/backend/src/workspaces/types/update-workspace-title-response.type.ts
+++ b/backend/src/workspaces/types/update-workspace-title-response.type.ts
@@ -1,0 +1,3 @@
+import { WorkspaceDomain } from "./workspace-domain.type";
+
+export class UpdateWorkspaceTitleResponse extends WorkspaceDomain {}

--- a/backend/src/workspaces/workspaces.controller.ts
+++ b/backend/src/workspaces/workspaces.controller.ts
@@ -5,6 +5,7 @@ import {
 	Get,
 	Param,
 	ParseIntPipe,
+	Patch,
 	Post,
 	Query,
 	Req,
@@ -27,11 +28,13 @@ import { AuthorizedRequest } from "src/utils/types/req.type";
 import { CreateInvitationTokenDto } from "./dto/create-invitation-token.dto";
 import { CreateWorkspaceDto } from "./dto/create-workspace.dto";
 import { JoinWorkspaceDto } from "./dto/join-workspace.dto";
+import { UpdateWorkspaceTitleDto } from "./dto/update-workspace-title.dto";
 import { CreateInvitationTokenResponse } from "./types/create-inviation-token-response.type";
 import { CreateWorkspaceResponse } from "./types/create-workspace-response.type";
 import { FindWorkspaceResponse } from "./types/find-workspace-response.type";
 import { FindWorkspacesResponse } from "./types/find-workspaces-response.type";
 import { JoinWorkspaceResponse } from "./types/join-workspace-response.type";
+import { UpdateWorkspaceTitleResponse } from "./types/update-workspace-title-response.type";
 import { WorkspacesService } from "./workspaces.service";
 
 @ApiTags("Workspaces")
@@ -147,5 +150,32 @@ export class WorkspacesController {
 		@Body() joinWorkspaceDto: JoinWorkspaceDto
 	): Promise<JoinWorkspaceResponse> {
 		return this.workspacesService.join(req.user.id, joinWorkspaceDto.invitationToken);
+	}
+
+	@Patch(":workspace_id/title")
+	@ApiOperation({
+		summary: "Update Workspace Title",
+		description: "Update the title of an existing workspace.",
+	})
+	@ApiParam({
+		name: "workspace_id",
+		description: "ID of workspace to update",
+	})
+	@ApiBody({ type: UpdateWorkspaceTitleDto })
+	@ApiOkResponse({ type: UpdateWorkspaceTitleResponse })
+	@ApiNotFoundResponse({
+		type: HttpExceptionResponse,
+		description: "Workspace not found, or the user lacks the appropriate permissions.",
+	})
+	async updateTitle(
+		@Req() req: AuthorizedRequest,
+		@Param("workspace_id") workspaceId: string,
+		@Body() updateWorkspaceTitleDto: UpdateWorkspaceTitleDto
+	): Promise<UpdateWorkspaceTitleResponse> {
+		return this.workspacesService.updateTitle(
+			req.user.id,
+			workspaceId,
+			updateWorkspaceTitleDto.title
+		);
 	}
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

**What this PR does / why we need it**:
This PR adds the ability to change workspace names after creation. It implements a rename functionality that allows users to update their workspace names through the UI, providing better flexibility for organizing and managing workspaces.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #179 

**Special notes for your reviewer**:
The workspace rename feature is not fully complete. So I guess I'll need to do some more frontend work on this PR.
To properly implement the workspace name change function, I need to work on the frontend, but I don't want to arbitrarily change the UI, so I've only implemented the API. Who should I discuss UI-related issues with?

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```

**Additional documentation**:

<!--
This section can be blank if this pull request does not require a release note.

Please use the following format for linking documentation:
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs
None
```

**Checklist**:
- [X] Added relevant tests or not required
- [X] Didn't break anything
