### PR TITLE
replace deprecated ListItemSecondaryAction with flexbox layout

### DIFF
--- a/frontend/src/components/popovers/WorkspaceListPopover.tsx
+++ b/frontend/src/components/popovers/WorkspaceListPopover.tsx
@@ -3,7 +3,6 @@ import {
 	CircularProgress,
 	Divider,
 	ListItemIcon,
-	ListItemSecondaryAction,
 	ListItemText,
 	MenuItem,
 	MenuList,
@@ -97,6 +96,11 @@ function WorkspaceListPopover(props: WorkspaceListPopoverProps) {
 								<MenuItem
 									key={workspace.id}
 									onClick={() => handleMoveToSelectedWorkspace(workspace.slug)}
+									sx={{
+										display: "flex",
+										alignItems: "center",
+										justifyContent: "space-between",
+									}}
 								>
 									<ListItemText
 										primaryTypographyProps={{
@@ -107,9 +111,7 @@ function WorkspaceListPopover(props: WorkspaceListPopoverProps) {
 										{workspace.title}
 									</ListItemText>
 									{params.workspaceSlug === workspace.slug && (
-										<ListItemSecondaryAction>
-											<CheckIcon fontSize="small" />
-										</ListItemSecondaryAction>
+										<CheckIcon fontSize="small" />
 									)}
 								</MenuItem>
 							))}


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

**What this PR does / why we need it**:
- Removed deprecated `ListItemSecondaryAction` component
- Replaced with flexbox layout using `sx` prop on `MenuItem`

mui ListItemSecondaryAction API is deprecated from mui/material v6. (https://mui.com/material-ui/api/list-item-secondary-action/)

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```

**Additional documentation**:

<!--
This section can be blank if this pull request does not require a release note.

Please use the following format for linking documentation:
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```

**Checklist**:
- [x] Added relevant tests or not required
- [x] Didn't break anything
