### PR TITLE
Decode workspace.slug to handle encoded Unicode characters properly

### DIFF
--- a/backend/src/files/files.service.ts
+++ b/backend/src/files/files.service.ts
@@ -53,7 +53,14 @@ export class FilesService {
 			throw new UnprocessableEntityException("Content length too long.");
 		}
 
-		const fileKey = `${workspace.slug}-${generateRandomKey()}.${contentType.split("/")[1]}`;
+		let decodedSlug: string;
+		try {
+			decodedSlug = decodeURIComponent(workspace.slug);
+		} catch {
+			decodedSlug = workspace.slug;
+		}
+
+		const fileKey = `${decodedSlug}-${generateRandomKey()}.${contentType.split("/")[1]}`;
 		const command = new PutObjectCommand({
 			Bucket: this.configService.get("BUCKET_NAME"),
 			Key: fileKey,


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

**What this PR does / why we need it**:
This PR fixes a bug where file uploads failed and MinIO/S3 returned `NoSuchKey` when the workspace name contained Korean (non-ASCII) characters.
To address the issue where the object key was being generated from a URL-encoded `workspace.slug`, we now apply `decodeURIComponent(workspace.slug)` so that a proper Unicode key is generated.
**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #530

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```

**Additional documentation**:

<!--
This section can be blank if this pull request does not require a release note.

Please use the following format for linking documentation:
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```

**Checklist**:
- [ ] Added relevant tests or not required
- [ ] Didn't break anything
