### PR TITLE
replace deprecated ListItemSecondaryAction with simple box

### DIFF
--- a/frontend/src/components/common/DraggableWorkspaceItem.tsx
+++ b/frontend/src/components/common/DraggableWorkspaceItem.tsx
@@ -1,12 +1,4 @@
-import {
-	ListItemText,
-	MenuItem,
-	IconButton,
-	Box,
-	ListItemSecondaryAction,
-	useMediaQuery,
-	useTheme,
-} from "@mui/material";
+import { ListItemText, MenuItem, IconButton, Box, useMediaQuery, useTheme } from "@mui/material";
 import DragIndicatorIcon from "@mui/icons-material/DragIndicator";
 import CheckIcon from "@mui/icons-material/Check";
 import { forwardRef } from "react";
@@ -121,9 +113,16 @@ const DraggableWorkspaceItem = forwardRef<HTMLLIElement, DraggableWorkspaceItemP
 				</ListItemText>
 
 				{isSelected && (
-					<ListItemSecondaryAction>
+					<Box
+						sx={{
+							position: "absolute",
+							right: 16,
+							top: "50%",
+							transform: "translateY(-50%)",
+						}}
+					>
 						<CheckIcon fontSize="small" color="primary" />
-					</ListItemSecondaryAction>
+					</Box>
 				)}
 			</MenuItem>
 		);


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

**What this PR does / why we need it**:
Removed deprecated ListItemSecondaryAction component
reopened #531 

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```

**Additional documentation**:

<!--
This section can be blank if this pull request does not require a release note.

Please use the following format for linking documentation:
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```

**Checklist**:
- [x] Added relevant tests or not required
- [x] Didn't break anything


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style**
  - Refined the selection indicator in draggable workspace items for clearer visuals: the checkmark now stays consistently right-aligned and vertically centered.
  - Prevents overlap with item content, improving readability in dense lists.
  - Indicator still appears only when an item is selected; no changes to interactions or behavior.
  - Overall visual polish to make selection state more obvious without altering existing workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->