### PR TITLE
Add Tag feature frontend for document management in Workspaces

### DIFF
--- a/frontend/src/components/common/DropdownTags.tsx
+++ b/frontend/src/components/common/DropdownTags.tsx
@@ -1,0 +1,134 @@
+import { useEffect, useState } from "react";
+import {
+	Box,
+	OutlinedInput,
+	InputLabel,
+	MenuItem,
+	FormControl,
+	ListItemText,
+	Select,
+	Checkbox,
+	SelectChangeEvent,
+} from "@mui/material";
+import { ALL_TAGS, TAGS, TagType } from "../../constants/tag";
+import TagChip from "../tags/TagChip";
+
+const ITEM_HEIGHT = 52;
+const ITEM_PADDING_TOP = 4;
+const MenuProps = {
+	PaperProps: {
+		style: {
+			maxHeight: ITEM_HEIGHT * 6 + ITEM_PADDING_TOP,
+			width: 360,
+		},
+	},
+};
+
+function ColorDot({ color }: { color: string }) {
+	return (
+		<Box
+			sx={{
+				width: 14,
+				height: 14,
+				borderRadius: "50%",
+				bgcolor: color,
+				border: "1px solid",
+				borderColor: "divider",
+				flexShrink: 0,
+			}}
+		/>
+	);
+}
+
+export type LabelDropdownProps = {
+	options?: TagType[];
+	label?: string;
+	value?: TagType[];
+	onChange?: (v: TagType[]) => void;
+	fullWidth?: boolean;
+};
+
+export default function DropdownTags({
+	options = ALL_TAGS,
+	label = "Add tags...",
+	value,
+	onChange,
+	fullWidth = false,
+}: LabelDropdownProps) {
+	const [selectedTags, setSelectedTags] = useState<TagType[]>(value ?? []);
+
+	useEffect(() => {
+		if (value !== undefined) {
+			setSelectedTags(value);
+		}
+	}, [value]);
+
+	const handleChange = (event: SelectChangeEvent<TagType[]>) => {
+		const newSelected = event.target.value as TagType[];
+		setSelectedTags(newSelected);
+		onChange?.(newSelected);
+	};
+
+	return (
+		<FormControl size="small" sx={{ m: 1, width: 200 }} fullWidth={fullWidth}>
+			<InputLabel id="tags-multiple-checkbox-label" sx={{ color: "white" }}>
+				{label}
+			</InputLabel>
+			<Select
+				labelId="tags-multiple-checkbox-label"
+				id="tags-multiple-checkbox"
+				multiple
+				value={selectedTags}
+				onChange={handleChange}
+				input={<OutlinedInput label={label} />}
+				MenuProps={MenuProps}
+				sx={{
+					".MuiOutlinedInput-notchedOutline": {
+						borderColor: "white",
+					},
+					"&:hover .MuiOutlinedInput-notchedOutline": {
+						borderColor: "white",
+					},
+					".MuiSvgIcon-root": {
+						color: "white",
+					},
+				}}
+				renderValue={(selected) => {
+					if (selected.length === 0) {
+						return <Box sx={{ color: "text.disabled" }}>{label}</Box>;
+					}
+					return (
+						<Box sx={{ display: "flex", flexWrap: "wrap", gap: 0.5 }}>
+							{selected.map((tag) => (
+								<TagChip key={tag} name={tag} size="small" />
+							))}
+						</Box>
+					);
+				}}
+			>
+				{options.map((tag) => {
+					const isChecked = selectedTags.includes(tag);
+					const meta = TAGS[tag];
+
+					return (
+						<MenuItem key={tag} value={tag} sx={{ py: 1.25 }}>
+							<Checkbox checked={isChecked} sx={{ mr: 1, p: 0 }} />
+							<Box sx={{ mr: 1.5, mt: "2px" }}>
+								<ColorDot color={meta.bg} />
+							</Box>
+							<ListItemText
+								primary={tag}
+								secondary={meta.description}
+								primaryTypographyProps={{ fontWeight: 600 }}
+								secondaryTypographyProps={{
+									variant: "body2",
+									color: "text.secondary",
+								}}
+							/>
+						</MenuItem>
+					);
+				})}
+			</Select>
+		</FormControl>
+	);
+}

--- a/frontend/src/components/headers/DocumentHeader.tsx
+++ b/frontend/src/components/headers/DocumentHeader.tsx
@@ -41,6 +41,10 @@ function DocumentHeader() {
 	const { enqueueSnackbar } = useSnackbar();
 	const [moreButtonAnchorEl, setMoreButtonAnchorEl] = useState<HTMLButtonElement | null>(null);
 	const isWideEnough = useMediaQuery(`(min-width:${DRAWER_WIDTH + 512}px)`);
+	{
+		/* TODO(yeonthusiast): When the tagging is implemented, uncomment the following code */
+	}
+	// const [value, setValue] = useState<TagType[]>([]);
 
 	useEffect(() => {
 		if (editorState.shareRole === ShareRole.READ) {
@@ -145,7 +149,9 @@ function DocumentHeader() {
 					</Box>
 
 					<Box>
-						<Stack direction="row" justifyContent="end" gap={1}>
+						<Stack direction="row" justifyContent="end" gap={1} alignItems="center">
+							{/* TODO(yeonthusiast): When the tagging is implemented, uncomment the following code */}
+							{/* <DropdownTags value={value} onChange={setValue} /> */}
 							<UserPresenceList presenceList={presenceList} />
 							{!editorState.shareRole && <ShareButton />}
 							<IconButton color="inherit" onClick={handleMoreButtonClick}>

--- a/frontend/src/components/tags/TagChip.tsx
+++ b/frontend/src/components/tags/TagChip.tsx
@@ -1,0 +1,35 @@
+import { Chip, ChipProps } from "@mui/material";
+import { TAGS, TagType } from "../../constants/tag";
+
+export type TagChipProps = Omit<ChipProps, "label" | "color"> & {
+	name: TagType;
+};
+
+export default function TagChip({
+	name,
+	variant = "filled",
+	size = "small",
+	...rest
+}: TagChipProps) {
+	const meta = TAGS[name];
+	if (!meta) return null;
+
+	const bg = meta.bg;
+	const fg = meta.fg;
+
+	const chip = (
+		<Chip
+			size={size}
+			label={name}
+			variant={variant}
+			sx={{
+				bgcolor: bg,
+				color: fg,
+				fontWeight: "bold",
+			}}
+			{...rest}
+		/>
+	);
+
+	return chip;
+}

--- a/frontend/src/constants/tag.ts
+++ b/frontend/src/constants/tag.ts
@@ -1,0 +1,30 @@
+export type TagMeta = {
+	label?: string;
+	bg: string;
+	fg: string;
+	description?: string;
+};
+
+export const TAGS = {
+	bug: { bg: "#d73a4a", fg: "#ffffff", description: "an unexpected problem" },
+	documentation: { bg: "#0075ca", fg: "#ffffff", description: "a need for improvements" },
+	duplicate: { bg: "#cfd3d7", fg: "#24292e", description: "similar issues" },
+	enhancement: { bg: "#a2eeef", fg: "#0b4f6c", description: "new feature requests" },
+	"good first issue": {
+		bg: "#7057ff",
+		fg: "#ffffff",
+		description: "a good issue for first-time contributors",
+	},
+	"help wanted": {
+		bg: "#008672",
+		fg: "#ffffff",
+		description: "a maintainer wants help on an issue",
+	},
+	invalid: { bg: "#e4e669", fg: "#24292e", description: "an issue is no longer relevant" },
+	question: { bg: "#d876e3", fg: "#ffffff", description: "an issue needs more information" },
+	wontfix: { bg: "#ffffff", fg: "#24292e", description: "work won't continue on an issue" },
+} as const satisfies Record<string, TagMeta>;
+
+export type TagType = keyof typeof TAGS;
+
+export const ALL_TAGS = Object.keys(TAGS) as (keyof typeof TAGS)[];


### PR DESCRIPTION
**What this PR does / why we need it**:
As the number of documents in a workspace grows, it becomes harder to find the desired ones. To address this, we introduce a document tagging feature that allows users to filter and view only the documents with selected tags in the workspace.

**Which issue(s) this PR fixes**:
Fixes #132 

**Special notes for your reviewer**:
Since I don’t have backend development expertise, I could only implement the basic frontend part of this feature. In this PR, I created GitHub label–based tag chips and made them selectable in the document editing view. However, selected tags are not yet saved. **Backend support is required to persist and retrieve these tags.** Once that functionality is in place, I will be able to implement filtering documents by tags in the workspace.

https://github.com/user-attachments/assets/944056bb-e752-436e-80a1-490a914f8150



**Does this PR introduce a user-facing change?**:
```release-note
NONE (the feature is incomplete and has been commented out for now).
```

**Additional documentation**:
[github labels](https://docs.github.com/en/issues/using-labels-and-milestones-to-track-work/managing-labels)


**Checklist**:
- [ ] Added relevant tests or not required
- [ ] Didn't break anything


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Added a reusable multi-select tag dropdown with checkboxes and color indicators; shows selected tags as chips.
  - Introduced colored tag chips for consistent tag styling across the app.
  - Provided a built-in tag catalog with names, colors, and descriptions to power the UI.

- Style
  - Improved header actions alignment for better visual balance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->