### PR TITLE
fix: prevent code highlighting if no language provided

### DIFF
--- a/frontend/src/components/editor/Preview.tsx
+++ b/frontend/src/components/editor/Preview.tsx
@@ -61,6 +61,9 @@ const md = new MarkdownIt({
 	linkify: true,
 	breaks: true,
 	highlight: (code: string, lang: string): string => {
+		if (lang.trim() === "") {
+			return `<pre><code>${md.utils.escapeHtml(code)}</code></pre>`;
+		}
 		try {
 			return `<pre class="language-${lang}"><code>${toHtml(
 				// eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -68,7 +71,7 @@ const md = new MarkdownIt({
 			)}</code></pre>`;
 		} catch (error) {
 			console.error(`Error highlighting code with language '${lang}':`, error);
-			return `<pre class="language-"><code>${md.utils.escapeHtml(code)}</code></pre>`;
+			return `<pre><code>${md.utils.escapeHtml(code)}</code></pre>`;
 		}
 	},
 })


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

**What this PR does / why we need it**:

Currently, code fences without language metadata still trigger code highlighter and highlighter attempts to match against all possible languages, which consumes considerable resources and time.

This PR adds an early return when no language is provided in codefence, to prevent unnecessary code highlighter calls.


**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #546

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```

**Additional documentation**:

I tested performance by inputting ~180 of the following code fences (~55,000 lines):
````
```
aaa
```
````

before patch(as-is):
<img width="242" height="138" alt="SCR-20251109-opbb" src="https://github.com/user-attachments/assets/4ab8e7f6-4951-4195-acff-1068e476cde8" />

after patch(to-be):
<img width="256" height="134" alt="SCR-20251109-opjq" src="https://github.com/user-attachments/assets/01fe86aa-9cef-4816-afc6-473e9c124ce6" />



<!--
This section can be blank if this pull request does not require a release note.

Please use the following format for linking documentation:
- [Usage]: <link>
- [Other doc]: <link>
-->


**Checklist**:
- [x] Added relevant tests or not required
- [x] Didn't break anything


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved code block rendering in the editor. Code blocks without a specified language now display as plain text, and highlighting failures gracefully fall back to plain text rendering instead of showing language-specific formatting issues.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->