### PR TITLE
Add user profile image support across backend and frontend

### DIFF
--- a/packages/backend/prisma/schema.prisma
+++ b/packages/backend/prisma/schema.prisma
@@ -15,6 +15,7 @@ model User {
   socialProvider      String            @map("social_provider")
   socialUid           String            @unique @map("social_uid")
   nickname            String?
+  profileIcon         String?           @map("profile_icon")
   createdAt           DateTime          @default(now()) @map("created_at")
   updatedAt           DateTime          @updatedAt @map("updated_at")
   userWorkspaceList   UserWorkspace[]

--- a/packages/backend/src/auth/auth.service.ts
+++ b/packages/backend/src/auth/auth.service.ts
@@ -17,7 +17,8 @@ export class AuthService {
 	async loginWithSocialProvider(req: LoginRequest): Promise<LoginResponse> {
 		const user = await this.usersService.findOrCreate(
 			req.user.socialProvider,
-			req.user.socialUid
+			req.user.socialUid,
+			req.user.profileIcon
 		);
 
 		const accessToken = this.jwtAccessService.sign({ sub: user.id, nickname: user.nickname });

--- a/packages/backend/src/auth/github.strategy.ts
+++ b/packages/backend/src/auth/github.strategy.ts
@@ -27,6 +27,7 @@ export class GithubStrategy extends PassportStrategy(Strategy, "github") {
 			socialProvider: "github",
 			socialUid: profile.id,
 			nickname: profile.username,
+			profileIcon: profile.photos?.[0]?.value || null,
 		};
 	}
 }

--- a/packages/backend/src/auth/types/login-request.type.ts
+++ b/packages/backend/src/auth/types/login-request.type.ts
@@ -4,6 +4,7 @@ export interface LoginUserInfo {
 	socialProvider: SocialProvider;
 	socialUid: string;
 	nickname: string;
+	profileIcon: string | null;
 }
 
 export type LoginRequest = Request & { user: LoginUserInfo };

--- a/packages/backend/src/users/types/user-domain.type.ts
+++ b/packages/backend/src/users/types/user-domain.type.ts
@@ -5,6 +5,10 @@ export class UserDomain {
 	id: string;
 	@ApiProperty({ type: String, description: "Nickname of user", required: false })
 	nickname?: string;
+	@ApiProperty({ type: String, description: "Profile icon of user", required: false })
+	profileIcon?: string;
+	@ApiProperty({ type: String, description: "Last workspace slug of user", required: false })
+	lastWorkspaceSlug?: string;
 	@ApiProperty({ type: Date, description: "Created date of user" })
 	createdAt: Date;
 	@ApiProperty({ type: Date, description: "Updated date of user" })

--- a/packages/backend/src/users/users.service.ts
+++ b/packages/backend/src/users/users.service.ts
@@ -17,6 +17,7 @@ export class UsersService {
 			select: {
 				id: true,
 				nickname: true,
+				profileIcon: true,
 				createdAt: true,
 				updatedAt: true,
 			},
@@ -28,7 +29,11 @@ export class UsersService {
 		return foundUser;
 	}
 
-	async findOrCreate(socialProvider: string, socialUid: string): Promise<User | null> {
+	async findOrCreate(
+		socialProvider: string,
+		socialUid: string,
+		profileIcon: string | null
+	): Promise<User | null> {
 		const foundUser = await this.prismaService.user.findFirst({
 			where: {
 				socialProvider,
@@ -37,6 +42,12 @@ export class UsersService {
 		});
 
 		if (foundUser) {
+			if (profileIcon && foundUser.profileIcon !== profileIcon) {
+				return await this.prismaService.user.update({
+					where: { id: foundUser.id },
+					data: { profileIcon },
+				});
+			}
 			return foundUser;
 		}
 
@@ -44,6 +55,7 @@ export class UsersService {
 			data: {
 				socialProvider,
 				socialUid,
+				profileIcon: profileIcon || null,
 			},
 		});
 

--- a/packages/backend/src/users/users.service.ts
+++ b/packages/backend/src/users/users.service.ts
@@ -42,6 +42,8 @@ export class UsersService {
 		});
 
 		if (foundUser) {
+			// TODO: When user profile image change feature is added,
+			// this should be revisited to avoid overwriting user-uploaded images on re-login.
 			if (profileIcon && foundUser.profileIcon !== profileIcon) {
 				return await this.prismaService.user.update({
 					where: { id: foundUser.id },

--- a/packages/backend/src/workspace-users/types/workspace-user.domain.ts
+++ b/packages/backend/src/workspace-users/types/workspace-user.domain.ts
@@ -5,6 +5,8 @@ export class WorkspaceUserDomain {
 	id: string;
 	@ApiProperty({ type: String, description: "Nickname of the user" })
 	nickname: string;
+	@ApiProperty({ type: String, description: "Profile icon of the user", required: false })
+	profileIcon?: string;
 	@ApiProperty({ type: Date, description: "Created date of the user" })
 	createdAt: Date;
 	@ApiProperty({ type: Date, description: "Updated date of the user" })

--- a/packages/backend/src/workspace-users/workspace-users.service.ts
+++ b/packages/backend/src/workspace-users/workspace-users.service.ts
@@ -37,6 +37,7 @@ export class WorkspaceUsersService {
 			select: {
 				id: true,
 				nickname: true,
+				profileIcon: true,
 				updatedAt: true,
 				createdAt: true,
 			},

--- a/packages/codemirror/src/plugins/yorkie/yorkieSync.ts
+++ b/packages/codemirror/src/plugins/yorkie/yorkieSync.ts
@@ -10,6 +10,7 @@ export type YorkiePresenceType = {
 	color: string;
 	name: string;
 	selection: yorkie.TextPosStructRange | null;
+	profileIcon: string | null;
 	cursor: [number, number] | null;
 };
 

--- a/packages/frontend/src/components/cards/DocumentCard.tsx
+++ b/packages/frontend/src/components/cards/DocumentCard.tsx
@@ -26,12 +26,14 @@ function DocumentCard(props: DocumentCardProps) {
 		color: string;
 		name: string;
 		cursor: string | null;
+		profileIcon?: string | null;
 		selection: string | null;
 	}) => {
 		return {
 			color: data.color.replace(/^"|"$/g, ""),
 			name: data.name.replace(/^"|"$/g, ""),
 			cursor: data.cursor,
+			profileIcon: data.profileIcon ? data.profileIcon.replace(/^"|"$/g, "") : null,
 			selection: data.selection,
 		};
 	};
@@ -106,7 +108,12 @@ function DocumentCard(props: DocumentCardProps) {
 					}}
 				>
 					{presenceList.map((presence, index) => (
-						<Avatar key={index} sx={{ bgcolor: presence.color }} alt={presence.name}>
+						<Avatar
+							key={index}
+							src={presence.profileIcon || ""}
+							sx={{ bgcolor: presence.color }}
+							alt={presence.name}
+						>
 							{presence.name[0]}
 						</Avatar>
 					))}

--- a/packages/frontend/src/components/headers/SettingHeader.tsx
+++ b/packages/frontend/src/components/headers/SettingHeader.tsx
@@ -33,7 +33,9 @@ function SettingHeader() {
 					alignItems="center"
 				>
 					<IconButton onClick={handleOpenProfilePopover}>
-						<Avatar>{userStore.data?.nickname?.charAt(0)}</Avatar>
+						<Avatar src={userStore.data?.profileIcon || ""}>
+							{userStore.data?.nickname?.charAt(0)}
+						</Avatar>
 					</IconButton>
 					<IconButton onClick={handleToWorkspace}>
 						<CodePairIcon />

--- a/packages/frontend/src/components/headers/UserPresenceList.tsx
+++ b/packages/frontend/src/components/headers/UserPresenceList.tsx
@@ -42,6 +42,7 @@ function UserPresenceList(props: UserPresenceListProps) {
 			<Avatar
 				onClick={() => handleScrollToUserLocation(presence)}
 				alt={presence.presence.name}
+				src={presence.presence.profileIcon || ""}
 				sx={{ bgcolor: presence.presence.color }}
 			>
 				{presence.presence.name[0]}
@@ -80,6 +81,7 @@ function UserPresenceList(props: UserPresenceListProps) {
 						>
 							<ListItemAvatar>
 								<Avatar
+									src={presence.presence.profileIcon || ""}
 									sx={{
 										bgcolor: presence.presence.color,
 										width: 24,

--- a/packages/frontend/src/components/headers/WorkspaceHeader.tsx
+++ b/packages/frontend/src/components/headers/WorkspaceHeader.tsx
@@ -71,7 +71,9 @@ function WorkspaceHeader() {
 						width={DRAWER_WIDTH}
 					/>
 					<IconButton onClick={handleOpenProfilePopover}>
-						<Avatar>{userStore.data?.nickname?.charAt(0)}</Avatar>
+						<Avatar src={userStore.data?.profileIcon || ""}>
+							{userStore.data?.nickname?.charAt(0)}
+						</Avatar>
 					</IconButton>
 				</Stack>
 			</Toolbar>

--- a/packages/frontend/src/components/workspace/TableTab.tsx
+++ b/packages/frontend/src/components/workspace/TableTab.tsx
@@ -24,12 +24,14 @@ export default function TableContent({ documents }: { documents: Document[] }) {
 		color: string;
 		name: string;
 		cursor: string | null;
+		profileIcon?: string | null;
 		selection: string | null;
 	}) => {
 		return {
 			color: data.color.replace(/^"|"$/g, ""),
 			name: data.name.replace(/^"|"$/g, ""),
 			cursor: data.cursor,
+			profileIcon: data.profileIcon ? data.profileIcon.replace(/^"|"$/g, "") : null,
 			selection: data.selection,
 		};
 	};
@@ -84,6 +86,7 @@ export default function TableContent({ documents }: { documents: Document[] }) {
 										{presenceList.map((presence, index) => (
 											<Avatar
 												key={index}
+												src={presence.profileIcon || ""}
 												sx={{ bgcolor: presence.color }}
 												alt={presence.name}
 											>

--- a/packages/frontend/src/features/editor/hooks/useYorkieDocument.ts
+++ b/packages/frontend/src/features/editor/hooks/useYorkieDocument.ts
@@ -76,12 +76,13 @@ export const useYorkieDocument = (
 				initialPresence: {
 					name: presenceName,
 					color: Color(randomColor()).fade(0.15).toString(),
+					profileIcon: userStore.data?.profileIcon || null,
 					selection: null,
 					cursor: null,
 				},
 			});
 		},
-		[]
+		[userStore.data?.profileIcon]
 	);
 
 	const cleanUpYorkieDocument = useCallback(async () => {

--- a/packages/frontend/src/features/user/store/userSlice.ts
+++ b/packages/frontend/src/features/user/store/userSlice.ts
@@ -5,6 +5,8 @@ import { RootState } from "../../../store/store";
 export interface User {
 	id: string;
 	nickname: string | null;
+	profileIcon: string | null;
+	lastWorkspaceSlug: string;
 	updatedAt: Date;
 	createdAt: Date;
 }
@@ -38,6 +40,8 @@ export const selectUser = (state: RootState) => state.user;
  * - Storing user data, including:
  *   - `id`: Unique identifier for the user.
  *   - `nickname`: User's nickname, or `null` if not set.
+ *   - `profileIcon`: User's profile icon URL, or `null` if not set.
+ *   - `lastWorkspaceSlug`: The last accessed workspace's slug.
  *   - `updatedAt`: Timestamp of the last user update.
  *   - `createdAt`: Timestamp of when the user was created.
  */

--- a/packages/frontend/src/hooks/api/types/document.d.ts
+++ b/packages/frontend/src/hooks/api/types/document.d.ts
@@ -14,6 +14,7 @@ export class Document {
 				color: string;
 				cursor: string | null;
 				name: string;
+				profileIcon?: string | null;
 				selection: string | null;
 			};
 		}

--- a/packages/frontend/src/hooks/api/types/user.d.ts
+++ b/packages/frontend/src/hooks/api/types/user.d.ts
@@ -1,6 +1,8 @@
 export class User {
 	id: string;
 	nickname?: string | null;
+	profileIcon?: string | null;
+	lastWorkspaceSlug?: string | null;
 	createdAt: Date;
 	updatedAt: Date;
 }

--- a/packages/frontend/src/pages/settings/profile/Index.tsx
+++ b/packages/frontend/src/pages/settings/profile/Index.tsx
@@ -54,6 +54,7 @@ function ProfileIndex() {
 		<Container sx={{ height: "calc(100vh - 88px)", width: "100%" }}>
 			<Stack alignItems="center" justifyContent="center" gap={6} sx={{ height: 1 }}>
 				<Avatar
+					src={userStore.data?.profileIcon || ""}
 					sx={{
 						width: avatarSize,
 						height: avatarSize,


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

**What this PR does / why we need it**:

Implemented user profile image support across both the backend and frontend.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #348

**Special notes for your reviewer**:
- Added profileIcon field in User model
- Conditional logic was used to avoid unnecessary queries during profile image updates, so a unique composite key was not added

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
Users can now view their own and others' GitHub profile images across headers, document cards, and table tabs.
```
<img width="927" height="246" alt="header" src="https://github.com/user-attachments/assets/314737c0-65e3-45bc-81e5-8e639fbecfd3" />
<br>
<img width="598" height="337" alt="document_card" src="https://github.com/user-attachments/assets/b7b03bb5-0355-4c07-91ed-ad830c509911" />
<br>
<img width="888" height="293" alt="table" src="https://github.com/user-attachments/assets/266738aa-a562-4827-bf1d-639a36efa60a" />
<br>
<img width="778" height="208" alt="image" src="https://github.com/user-attachments/assets/a6b6d6e3-f011-4bd7-96ed-c49c771cf9d7" />


**Additional documentation**:

<!--
This section can be blank if this pull request does not require a release note.

Please use the following format for linking documentation:
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```

**Checklist**:
- [x] Added relevant tests or not required
- [x] Didn't break anything


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * User profile icons from social authentication accounts are now captured and displayed throughout the application, including in headers, presence indicators, and user collaboration features.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->