### PR TITLE
Hide workspace delete button in production mode

### DIFF
--- a/frontend/src/pages/workspace/Index.tsx
+++ b/frontend/src/pages/workspace/Index.tsx
@@ -139,11 +139,12 @@ function WorkspaceIndex() {
 						>
 							New Note
 						</Button>
-						{/* NOTE(kokodak): Delete workspace button should only be always visible after
+						{/* NOTE(kokodak): Delete workspace button should be visible after
 							the following requirements are met:
 							- Members should NOT see the delete button.
 							- Even Owners should go through an extra confirmation step before delete.
 							Once these requirements are met, we can safely remove the MODE condition below.
+							For more details, see PR #556: https://github.com/yorkie-team/codepair/pull/556
 						*/}
 						{import.meta.env.MODE !== "production" && (
 							<Button


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

**What this PR does / why we need it**:
This PR hides the Workspace delete button using Vite's `MODE` environment variable. Since Workspace deletion is a high-risk operation, we temporarily disable the button in the production environment to enhance user safety. Once the following defensive UI measures are fully in place, we may consider re-enabling the delete button:

- The delete button will NOT be visible to users with Member permissions.
- Even for Owner users, an additional confirmation layer will be introduced before deletion.

These restrictions aim to minimize accidental deletions and ensure that Workspace removal is a deliberate and well-informed action.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```

**Additional documentation**:

<!--
This section can be blank if this pull request does not require a release note.

Please use the following format for linking documentation:
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```

**Checklist**:
- [x] Added relevant tests or not required
- [x] Didn't break anything


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * The workspace Delete button is now hidden in production and remains available in non-production modes to reduce risk; its appearance and click behavior are unchanged.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->