### PR TITLE
Adjust Workspace Layout  max width based on drawer state

### DIFF
--- a/frontend/src/components/layouts/WorkspaceLayout.tsx
+++ b/frontend/src/components/layouts/WorkspaceLayout.tsx
@@ -10,6 +10,7 @@ import { useEffect } from "react";
 import { useParams } from "react-router-dom";
 import { selectUser } from "../../store/userSlice";
 import { setLastWorkspaceSlug } from "../../utils/lastWorkspace";
+import { DRAWER_WIDTH, COLLAPSED_DRAWER_WIDTH } from "../../constants/layout";
 
 export const WorkspaceDrawerHeader = styled("div")(({ theme }) => ({
 	display: "flex",
@@ -36,7 +37,11 @@ function WorkspaceLayout() {
 			<WorkspaceHeader />
 			<Stack direction="row">
 				<WorkspaceDrawer open={drawerOpen} />
-				<Box flexGrow={1} maxWidth="100%" px={2}>
+				<Box
+					flexGrow={1}
+					maxWidth={`calc(100% - ${drawerOpen ? DRAWER_WIDTH : COLLAPSED_DRAWER_WIDTH}px)`}
+					px={2}
+				>
 					<WorkspaceDrawerHeader />
 					<Box mx="auto" maxWidth={1440} width="100%">
 						<Outlet />


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

**What this PR does / why we need it**:

Adjust Workspace Layout  max width based on drawer state

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

**Special notes for your reviewer**:

[screen-capture.webm](https://github.com/user-attachments/assets/ff6447b5-f41a-406d-99ab-7aa1096aab15)

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```

**Additional documentation**:

<!--
This section can be blank if this pull request does not require a release note.

Please use the following format for linking documentation:
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```

**Checklist**:
- [ ] Added relevant tests or not required
- [ ] Didn't break anything


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed layout issue where the main content area did not properly adjust its width when toggling the workspace drawer open or closed. The content area now dynamically resizes to accommodate the drawer state.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->