### PR TITLE
Apply Vim keybindings for Yorkie undo/redo

### DIFF
--- a/frontend/src/components/editor/Editor.tsx
+++ b/frontend/src/components/editor/Editor.tsx
@@ -40,7 +40,7 @@ function Editor(props: EditorProps) {
 	const workspaceStore = useSelector(selectWorkspace);
 	const { mutateAsync: createUploadUrl } = useCreateUploadUrlMutation();
 	const { mutateAsync: uploadFile } = useUploadFileMutation();
-	const { applyFormat, setKeymapConfig } = useFormatUtils();
+	const { applyFormat, setKeymapConfig, setupVimKeybindings } = useFormatUtils();
 	const { toolBarState, setToolBarState, updateFormatBar } = useToolBar();
 
 	const {
@@ -77,6 +77,11 @@ function Editor(props: EditorProps) {
 
 			return `${import.meta.env.VITE_API_ADDR}/files/${uploadUrlData.fileKey}`;
 		};
+
+		// Setup vim keybindings when vim mode is activated
+		if (configStore.codeKey === CodeKeyType.VIM) {
+			setupVimKeybindings();
+		}
 
 		const state = EditorState.create({
 			doc: editorStore.doc.getRoot().content?.toString() ?? "",
@@ -122,6 +127,7 @@ function Editor(props: EditorProps) {
 		applyFormat,
 		updateFormatBar,
 		setKeymapConfig,
+		setupVimKeybindings,
 	]);
 
 	return (

--- a/frontend/src/hooks/useFormatUtils.ts
+++ b/frontend/src/hooks/useFormatUtils.ts
@@ -5,6 +5,7 @@ import { indentWithTab } from "@codemirror/commands";
 import { Dispatch, SetStateAction } from "react";
 import { useSelector } from "react-redux";
 import { selectEditor } from "../store/editorSlice";
+import { Vim } from "@replit/codemirror-vim";
 
 export interface ToolBarState {
 	show: boolean;
@@ -125,6 +126,25 @@ export const useFormatUtils = () => {
 		return true;
 	}, [doc]);
 
+	// Setup Vim keybindings to use Yorkie undo/redo
+	const setupVimKeybindings = useCallback(() => {
+		// Map 'u' key in vim mode to Yorkie undo
+		Vim.defineAction("yorkieUndo", () => {
+			handleYorkieUndo();
+		});
+
+		// Map redo command in vim mode to Yorkie redo
+		Vim.defineAction("yorkieRedo", () => {
+			handleYorkieRedo();
+		});
+
+		// Map 'u' key to Yorkie undo action
+		Vim.mapCommand("u", "action", "yorkieUndo", {}, { context: "normal" });
+
+		// Map 'Ctrl-r' key to Yorkie redo action
+		Vim.mapCommand("<C-r>", "action", "yorkieRedo", {}, { context: "normal" });
+	}, [handleYorkieUndo, handleYorkieRedo]);
+
 	const setKeymapConfig = useCallback(
 		() => [
 			indentWithTab,
@@ -186,5 +206,6 @@ export const useFormatUtils = () => {
 		checkAndAddFormat,
 		handleYorkieUndo,
 		handleYorkieRedo,
+		setupVimKeybindings,
 	};
 };


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

**What this PR does / why we need it**:

Apply Vim keybindings for Yorkie undo/redo

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```

**Additional documentation**:

<!--
This section can be blank if this pull request does not require a release note.

Please use the following format for linking documentation:
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```

**Checklist**:
- [x] Added relevant tests or not required
- [x] Didn't break anything


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Vim keybindings are now available in the editor with support for undo and redo commands in Vim mode.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->