### PR TITLE
Update CHANGELOG.md for v0.2.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ and CodePair adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ## [Unreleased]
 
+## [0.2.2] - 2026-04-27
+
+### Changed
+
+- Bump up @yorkie-js/sdk to v0.7.7 by @hackerwins in https://github.com/yorkie-team/codepair/pull/597
+- Apply team docs pattern by @hackerwins in https://github.com/yorkie-team/codepair/pull/594
+
 ## [0.2.0] - 2026-01-29
 
 ### Added

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "codepair",
-  "version": "0.2.0",
+  "version": "0.2.2",
   "description": "Build your own AI-powered collaborative markdown editor in just 5 minutes",
   "keywords": [],
   "author": "yorkie-team",

--- a/packages/backend/package.json
+++ b/packages/backend/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@codepair/backend",
-	"version": "0.2.0",
+	"version": "0.2.2",
 	"description": "CodePair Backend",
 	"author": "yorkie-team",
 	"license": "Apache-2.0",

--- a/packages/frontend/package.json
+++ b/packages/frontend/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@codepair/frontend",
-	"version": "0.2.0",
+	"version": "0.2.2",
 	"description": "CodePair Frontend",
 	"type": "module",
 	"author": "yorkie-team",


### PR DESCRIPTION
## Summary
- Bump version to 0.2.2 in root, frontend, and backend package.json
- Add CHANGELOG entry for v0.2.2

## Changes in this release
- Bump up @yorkie-js/sdk to v0.7.7 (#597)
- Apply team docs pattern (#594)

🤖 Generated with [Claude Code](https://claude.com/claude-code)