### PR TITLE
Link docs hierarchy from README and fix broken CONTRIBUTING.md paths

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ CodePair provides the following features:
 
 This repository contains multiple packages that make up our project, organized as a pnpm workspace under `packages/`.
 
-- **`@codepair/frontend`**: App shell — routing, auth, workspace, editor slot. See [packages/frontend/](packages/frontend/) for details.
+- **`@codepair/frontend`**: App shell — routing, auth, workspace, editor slot. See [packages/frontend/README.md](packages/frontend/README.md) for details.
 - **`@codepair/backend`**: NestJS API server. See [packages/backend/README.md](packages/backend/README.md) for details.
 - **`@codepair/codemirror`**: CodeMirror 6 editor with Yorkie sync, toolbar, preview. Self-contained vertical slice.
 - **`@codepair/ui`**: Shared types (`EditorPort`, `EditorModeType`, `PresenceInfo`) and pure UI components.
@@ -126,6 +126,17 @@ We offer two options. Choose the one that best suits your needs:
 ## Contributing
 
 See [CONTRIBUTING](CONTRIBUTING.md) for details on submitting patches and the contribution workflow.
+
+## Documentation
+
+- [docs/design/](docs/design/README.md) — Architectural design documents
+- [docs/tasks/](docs/tasks/README.md) — Task tracking (active and archived)
+- [docs/editor-port-architecture.md](docs/editor-port-architecture.md) — Editor port architecture overview
+- [packages/frontend/design/](packages/frontend/design/README.md) — Frontend-specific design docs
+- [packages/backend/design/](packages/backend/design/README.md) — Backend-specific design docs
+- [CHANGELOG.md](CHANGELOG.md) — Release notes
+- [MAINTAINING.md](MAINTAINING.md) — Release and maintenance procedures
+- [CLAUDE.md](CLAUDE.md) — Agent instructions for AI-assisted development
 
 ## Contributors ✨
 

--- a/docs/tasks/README.md
+++ b/docs/tasks/README.md
@@ -1,8 +1,8 @@
 ---
-updated: 2026-03-25
+updated: 2026-04-29
 ---
 
 # Tasks
 
-- `active/` — In-progress tasks
-- `archive/` — Completed tasks
+- [active/](active/README.md) — In-progress tasks
+- [archive/](archive/README.md) — Completed tasks

--- a/packages/backend/README.md
+++ b/packages/backend/README.md
@@ -154,4 +154,5 @@ packages/backend/
 ## Contributing
 
 Please see the [CONTRIBUTING.md](../../CONTRIBUTING.md) file for details on how to contribute to this project.  
-If you are interested in internal design, please refer to the [Design Document](./design/).
+If you are interested in internal design, please refer to the [Design Document](./design/README.md).
+For the local MongoDB replica set used in development, see [docker/mongodb_replica/README.md](./docker/mongodb_replica/README.md).

--- a/packages/backend/design/README.md
+++ b/packages/backend/design/README.md
@@ -16,4 +16,4 @@ Writing a design document for big features has many advantages:
 
 While working on your design, writing code to prototype your functionality may be useful to refine your approach.
 
-Authoring Design document is also proceeded in the same [contribution flow](../../CONTRIBUTING.md) as normal Pull Request such as function implementation or bug fixing.
+Authoring Design document is also proceeded in the same [contribution flow](../../../CONTRIBUTING.md) as normal Pull Request such as function implementation or bug fixing.

--- a/packages/frontend/README.md
+++ b/packages/frontend/README.md
@@ -148,4 +148,4 @@ frontend/
 
 ## Contributing
 
-Please see the [CONTRIBUTING.md](../CONTRIBUTING.md) file for details on how to contribute to this project.
+Please see the [CONTRIBUTING.md](../../CONTRIBUTING.md) file for details on how to contribute to this project.

--- a/packages/frontend/design/README.md
+++ b/packages/frontend/design/README.md
@@ -17,4 +17,4 @@ Writing a design document for big features has many advantages:
 
 While working on your design, writing code to prototype your functionality may be useful to refine your approach.
 
-Authoring Design document is also proceeded in the same [contribution flow](../../CONTRIBUTING.md) as normal Pull Request such as function implementation or bug fixing.
+Authoring Design document is also proceeded in the same [contribution flow](../../../CONTRIBUTING.md) as normal Pull Request such as function implementation or bug fixing.


### PR DESCRIPTION
## Summary

- Add a Documentation section to \`README.md\` linking \`docs/design/\`, \`docs/tasks/\`, \`docs/editor-port-architecture.md\`, the per-package design docs, \`CHANGELOG.md\`, \`MAINTAINING.md\`, and \`CLAUDE.md\` so they are reachable from the project's entry point.
- Point the frontend Packages bullet at \`packages/frontend/README.md\` (the previous link to \`packages/frontend/\` had no \`.md\` so the link checker treated it as non-doc).
- Fix three broken \`CONTRIBUTING.md\` paths — they used one fewer parent hop than needed:
  - \`packages/frontend/README.md\`: \`../CONTRIBUTING.md\` → \`../../CONTRIBUTING.md\`
  - \`packages/frontend/design/README.md\` and \`packages/backend/design/README.md\`: \`../../CONTRIBUTING.md\` → \`../../../CONTRIBUTING.md\`
- Link \`backend/docker/mongodb_replica/README.md\` from the backend package README so the local-dev MongoDB setup is discoverable.
- Convert inline-code path references in \`docs/tasks/README.md\` to real markdown links.

Found via the link connectivity check script being added to second-brain ([yorkie-team/second-brain#34](https://github.com/yorkie-team/second-brain/pull/34)).

## Test plan

- [x] Verified the corrected CONTRIBUTING.md paths resolve to the repo-root file
- [x] Verified the new Documentation links resolve to existing files
- [ ] Reviewer to spot-check the new Documentation section