### PR TITLE
Add support for syncing document updatedAt from Yorkie webhook

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,20 +108,26 @@ We offer two options. Choose the one that best suits your needs:
    pnpm install
    ```
 
-4. Set up the Yorkie webhook:
+4. Enable Yorkie document syncing in `./packages/backend/.env.development`.
+
+   ```bash
+   YORKIE_DOCUMENT_SYNC=true
+   ```
+
+5. Set up the Yorkie webhook:
 
    ```bash
    pnpm setup:webhook
    ```
 
-5. Run the Backend application and the Frontend application:
+6. Run the Backend application and the Frontend application:
 
    ```bash
    pnpm backend start:dev
    pnpm frontend dev
    ```
 
-6. Visit http://localhost:5173 to enjoy your CodePair.
+7. Visit http://localhost:5173 to enjoy your CodePair.
 
 ## Contributing
 

--- a/packages/backend/src/settings/settings.service.spec.ts
+++ b/packages/backend/src/settings/settings.service.spec.ts
@@ -51,4 +51,21 @@ describe("SettingsService", () => {
 			},
 		});
 	});
+
+	it("should disable document sync when YORKIE_DOCUMENT_SYNC is not set", async () => {
+		configService.get.mockImplementation((key: string) => {
+			const config: Record<string, string> = {
+				YORKIE_INTELLIGENCE: "true",
+				FILE_UPLOAD: "s3",
+			};
+
+			return config[key];
+		});
+
+		await expect(service.getSettings()).resolves.toMatchObject({
+			documentSync: {
+				enable: false,
+			},
+		});
+	});
 });

--- a/packages/backend/src/settings/settings.service.spec.ts
+++ b/packages/backend/src/settings/settings.service.spec.ts
@@ -1,12 +1,34 @@
 import { Test, TestingModule } from "@nestjs/testing";
+import { ConfigService } from "@nestjs/config";
 import { SettingsService } from "./settings.service";
 
 describe("SettingsService", () => {
 	let service: SettingsService;
+	let configService: {
+		get: jest.Mock;
+	};
 
 	beforeEach(async () => {
+		configService = {
+			get: jest.fn((key: string) => {
+				const config: Record<string, string> = {
+					YORKIE_INTELLIGENCE: "true",
+					YORKIE_DOCUMENT_SYNC: "true",
+					FILE_UPLOAD: "s3",
+				};
+
+				return config[key];
+			}),
+		};
+
 		const module: TestingModule = await Test.createTestingModule({
-			providers: [SettingsService],
+			providers: [
+				SettingsService,
+				{
+					provide: ConfigService,
+					useValue: configService,
+				},
+			],
 		}).compile();
 
 		service = module.get<SettingsService>(SettingsService);
@@ -14,5 +36,19 @@ describe("SettingsService", () => {
 
 	it("should be defined", () => {
 		expect(service).toBeDefined();
+	});
+
+	it("should expose document sync settings", async () => {
+		await expect(service.getSettings()).resolves.toMatchObject({
+			yorkieIntelligence: {
+				enable: true,
+			},
+			documentSync: {
+				enable: true,
+			},
+			fileUpload: {
+				enable: true,
+			},
+		});
 	});
 });

--- a/packages/backend/src/settings/settings.service.ts
+++ b/packages/backend/src/settings/settings.service.ts
@@ -15,6 +15,9 @@ export class SettingsService {
 					features: generateFeatureList(this.configService),
 				},
 			},
+			documentSync: {
+				enable: this.configService.get("YORKIE_DOCUMENT_SYNC") === "true",
+			},
 			fileUpload: {
 				enable: this.configService.get("FILE_UPLOAD") !== "false",
 			},

--- a/packages/backend/src/settings/types/get-settings-response.type.ts
+++ b/packages/backend/src/settings/types/get-settings-response.type.ts
@@ -19,9 +19,20 @@ class FileUploadConfig {
 	enable: boolean;
 }
 
+class DocumentSyncConfig {
+	@ApiProperty({
+		type: Boolean,
+		description: "Enable syncing Yorkie document metadata from webhook events",
+	})
+	enable: boolean;
+}
+
 export class GetSettingsResponse {
 	@ApiProperty({ type: YorkieIntelligenceConfig, description: "Yorkie Intelligence Config" })
 	yorkieIntelligence: YorkieIntelligenceConfig;
+
+	@ApiProperty({ type: DocumentSyncConfig, description: "Yorkie document sync config" })
+	documentSync: DocumentSyncConfig;
 
 	@ApiProperty({ type: FileUploadConfig, description: "File Upload Config" })
 	fileUpload: FileUploadConfig;

--- a/packages/backend/src/yorkie/yorkie-event.service.spec.ts
+++ b/packages/backend/src/yorkie/yorkie-event.service.spec.ts
@@ -1,0 +1,189 @@
+import { Test, TestingModule } from "@nestjs/testing";
+import { ConfigService } from "@nestjs/config";
+import { PrismaService } from "src/db/prisma.service";
+import { IndexingQueueService } from "src/rag/indexing/indexing-queue.service";
+import { QdrantService } from "src/rag/qdrant/qdrant.service";
+import { DocumentEventType } from "./dto/document-event.dto";
+import { YorkieEventService } from "./yorkie-event.service";
+
+describe("YorkieEventService", () => {
+	let service: YorkieEventService;
+	let prismaService: {
+		document: {
+			findFirst: jest.Mock;
+			update: jest.Mock;
+		};
+	};
+	let indexingQueueService: {
+		scheduleIndexing: jest.Mock;
+	};
+	let qdrantService: {
+		getDocumentPoints: jest.Mock;
+	};
+	let configService: {
+		get: jest.Mock;
+	};
+
+	beforeEach(async () => {
+		prismaService = {
+			document: {
+				findFirst: jest.fn(),
+				update: jest.fn(),
+			},
+		};
+		indexingQueueService = {
+			scheduleIndexing: jest.fn(),
+		};
+		qdrantService = {
+			getDocumentPoints: jest.fn(),
+		};
+		configService = {
+			get: jest.fn((key: string) => {
+				if (key === "YORKIE_DOCUMENT_SYNC") {
+					return "true";
+				}
+
+				return undefined;
+			}),
+		};
+
+		const module: TestingModule = await Test.createTestingModule({
+			providers: [
+				YorkieEventService,
+				{
+					provide: PrismaService,
+					useValue: prismaService,
+				},
+				{
+					provide: IndexingQueueService,
+					useValue: indexingQueueService,
+				},
+				{
+					provide: QdrantService,
+					useValue: qdrantService,
+				},
+				{
+					provide: ConfigService,
+					useValue: configService,
+				},
+			],
+		}).compile();
+
+		service = module.get<YorkieEventService>(YorkieEventService);
+	});
+
+	it("should be defined", () => {
+		expect(service).toBeDefined();
+	});
+
+	it("should skip webhook processing when document sync is disabled", async () => {
+		configService.get.mockImplementation((key: string) => {
+			if (key === "YORKIE_DOCUMENT_SYNC") {
+				return "false";
+			}
+
+			return undefined;
+		});
+
+		await service.handleDocumentEvent({
+			type: DocumentEventType.DocumentRootChanged,
+			attributes: {
+				key: "doc-key",
+				issuedAt: "2026-01-20T12:00:00.000Z",
+			},
+		});
+
+		expect(prismaService.document.findFirst).not.toHaveBeenCalled();
+		expect(prismaService.document.update).not.toHaveBeenCalled();
+		expect(indexingQueueService.scheduleIndexing).not.toHaveBeenCalled();
+	});
+
+	it("should sync updatedAt and queue indexing when document sync is enabled", async () => {
+		const updatedAt = new Date("2026-01-20T11:00:00.000Z");
+		prismaService.document.findFirst.mockResolvedValue({
+			id: "document-id",
+			workspaceId: "workspace-id",
+			yorkieDocumentId: "doc-key",
+			updatedAt,
+		});
+		prismaService.document.update.mockResolvedValue({});
+		qdrantService.getDocumentPoints.mockResolvedValue([]);
+
+		await service.handleDocumentEvent({
+			type: DocumentEventType.DocumentRootChanged,
+			attributes: {
+				key: "doc-key",
+				issuedAt: "2026-01-20T12:00:00.000Z",
+			},
+		});
+
+		expect(prismaService.document.findFirst).toHaveBeenCalledWith({
+			where: {
+				yorkieDocumentId: "doc-key",
+			},
+			select: {
+				id: true,
+				workspaceId: true,
+				yorkieDocumentId: true,
+				updatedAt: true,
+			},
+		});
+		expect(prismaService.document.update).toHaveBeenCalledWith({
+			where: {
+				id: "document-id",
+			},
+			data: {
+				updatedAt: new Date("2026-01-20T12:00:00.000Z"),
+			},
+		});
+		expect(indexingQueueService.scheduleIndexing).toHaveBeenCalledWith(
+			"document-id",
+			"workspace-id",
+			30000
+		);
+	});
+
+	it("should not move updatedAt backwards for out-of-order webhook events", async () => {
+		const updatedAt = new Date("2026-01-20T12:00:00.000Z");
+		prismaService.document.findFirst.mockResolvedValue({
+			id: "document-id",
+			workspaceId: "workspace-id",
+			yorkieDocumentId: "doc-key",
+			updatedAt,
+		});
+		prismaService.document.update.mockResolvedValue({});
+		qdrantService.getDocumentPoints.mockResolvedValue([]);
+
+		await service.handleDocumentEvent({
+			type: DocumentEventType.DocumentRootChanged,
+			attributes: {
+				key: "doc-key",
+				issuedAt: "2026-01-20T11:00:00.000Z",
+			},
+		});
+
+		expect(prismaService.document.update).toHaveBeenCalledWith({
+			where: {
+				id: "document-id",
+			},
+			data: {
+				updatedAt,
+			},
+		});
+	});
+
+	it("should skip indexing when the Yorkie document does not map to a CodePair document", async () => {
+		prismaService.document.findFirst.mockResolvedValue(null);
+
+		await service.handleDocumentEvent({
+			type: DocumentEventType.DocumentRootChanged,
+			attributes: {
+				key: "missing-doc-key",
+				issuedAt: "2026-01-20T12:00:00.000Z",
+			},
+		});
+
+		expect(prismaService.document.update).not.toHaveBeenCalled();
+		expect(indexingQueueService.scheduleIndexing).not.toHaveBeenCalled();
+	});
+});

--- a/packages/backend/src/yorkie/yorkie-event.service.spec.ts
+++ b/packages/backend/src/yorkie/yorkie-event.service.spec.ts
@@ -162,14 +162,29 @@ describe("YorkieEventService", () => {
 			},
 		});
 
-		expect(prismaService.document.update).toHaveBeenCalledWith({
-			where: {
-				id: "document-id",
-			},
-			data: {
-				updatedAt,
+		expect(prismaService.document.update).not.toHaveBeenCalled();
+		expect(indexingQueueService.scheduleIndexing).not.toHaveBeenCalled();
+	});
+
+	it("should keep updatedAt unchanged for invalid webhook timestamps", async () => {
+		const updatedAt = new Date("2026-01-20T12:00:00.000Z");
+		prismaService.document.findFirst.mockResolvedValue({
+			id: "document-id",
+			workspaceId: "workspace-id",
+			yorkieDocumentId: "doc-key",
+			updatedAt,
+		});
+
+		await service.handleDocumentEvent({
+			type: DocumentEventType.DocumentRootChanged,
+			attributes: {
+				key: "doc-key",
+				issuedAt: "not-a-date",
 			},
 		});
+
+		expect(prismaService.document.update).not.toHaveBeenCalled();
+		expect(indexingQueueService.scheduleIndexing).not.toHaveBeenCalled();
 	});
 
 	it("should skip indexing when the Yorkie document does not map to a CodePair document", async () => {

--- a/packages/backend/src/yorkie/yorkie-event.service.spec.ts
+++ b/packages/backend/src/yorkie/yorkie-event.service.spec.ts
@@ -11,6 +11,7 @@ describe("YorkieEventService", () => {
 	let prismaService: {
 		document: {
 			findFirst: jest.Mock;
+			findUnique: jest.Mock;
 			update: jest.Mock;
 		};
 	};
@@ -25,9 +26,12 @@ describe("YorkieEventService", () => {
 	};
 
 	beforeEach(async () => {
+		jest.useFakeTimers();
+
 		prismaService = {
 			document: {
 				findFirst: jest.fn(),
+				findUnique: jest.fn(),
 				update: jest.fn(),
 			},
 		};
@@ -72,11 +76,15 @@ describe("YorkieEventService", () => {
 		service = module.get<YorkieEventService>(YorkieEventService);
 	});
 
+	afterEach(() => {
+		jest.useRealTimers();
+	});
+
 	it("should be defined", () => {
 		expect(service).toBeDefined();
 	});
 
-	it("should skip webhook processing when document sync is disabled", async () => {
+	it("should keep indexing enabled when document sync is disabled", async () => {
 		configService.get.mockImplementation((key: string) => {
 			if (key === "YORKIE_DOCUMENT_SYNC") {
 				return "false";
@@ -84,6 +92,13 @@ describe("YorkieEventService", () => {
 
 			return undefined;
 		});
+		prismaService.document.findFirst.mockResolvedValue({
+			id: "document-id",
+			workspaceId: "workspace-id",
+			yorkieDocumentId: "doc-key",
+			updatedAt: new Date("2026-01-20T11:00:00.000Z"),
+		});
+		qdrantService.getDocumentPoints.mockResolvedValue([]);
 
 		await service.handleDocumentEvent({
 			type: DocumentEventType.DocumentRootChanged,
@@ -93,18 +108,25 @@ describe("YorkieEventService", () => {
 			},
 		});
 
-		expect(prismaService.document.findFirst).not.toHaveBeenCalled();
+		expect(prismaService.document.findFirst).toHaveBeenCalled();
 		expect(prismaService.document.update).not.toHaveBeenCalled();
-		expect(indexingQueueService.scheduleIndexing).not.toHaveBeenCalled();
+		expect(indexingQueueService.scheduleIndexing).toHaveBeenCalledWith(
+			"document-id",
+			"workspace-id",
+			30000
+		);
 	});
 
-	it("should sync updatedAt and queue indexing when document sync is enabled", async () => {
-		const updatedAt = new Date("2026-01-20T11:00:00.000Z");
+	it("should debounce updatedAt sync when document sync is enabled", async () => {
+		const initialUpdatedAt = new Date("2026-01-20T11:00:00.000Z");
 		prismaService.document.findFirst.mockResolvedValue({
 			id: "document-id",
 			workspaceId: "workspace-id",
 			yorkieDocumentId: "doc-key",
-			updatedAt,
+			updatedAt: initialUpdatedAt,
+		});
+		prismaService.document.findUnique.mockResolvedValue({
+			updatedAt: initialUpdatedAt,
 		});
 		prismaService.document.update.mockResolvedValue({});
 		qdrantService.getDocumentPoints.mockResolvedValue([]);
@@ -117,14 +139,20 @@ describe("YorkieEventService", () => {
 			},
 		});
 
-		expect(prismaService.document.findFirst).toHaveBeenCalledWith({
+		expect(indexingQueueService.scheduleIndexing).toHaveBeenCalledWith(
+			"document-id",
+			"workspace-id",
+			30000
+		);
+		expect(prismaService.document.update).not.toHaveBeenCalled();
+
+		await jest.advanceTimersByTimeAsync(5000);
+
+		expect(prismaService.document.findUnique).toHaveBeenCalledWith({
 			where: {
-				yorkieDocumentId: "doc-key",
+				id: "document-id",
 			},
 			select: {
-				id: true,
-				workspaceId: true,
-				yorkieDocumentId: true,
 				updatedAt: true,
 			},
 		});
@@ -136,20 +164,18 @@ describe("YorkieEventService", () => {
 				updatedAt: new Date("2026-01-20T12:00:00.000Z"),
 			},
 		});
-		expect(indexingQueueService.scheduleIndexing).toHaveBeenCalledWith(
-			"document-id",
-			"workspace-id",
-			30000
-		);
 	});
 
-	it("should not move updatedAt backwards for out-of-order webhook events", async () => {
-		const updatedAt = new Date("2026-01-20T12:00:00.000Z");
+	it("should keep the latest issuedAt across rapid successive events", async () => {
+		const initialUpdatedAt = new Date("2026-01-20T11:00:00.000Z");
 		prismaService.document.findFirst.mockResolvedValue({
 			id: "document-id",
 			workspaceId: "workspace-id",
 			yorkieDocumentId: "doc-key",
-			updatedAt,
+			updatedAt: initialUpdatedAt,
+		});
+		prismaService.document.findUnique.mockResolvedValue({
+			updatedAt: initialUpdatedAt,
 		});
 		prismaService.document.update.mockResolvedValue({});
 		qdrantService.getDocumentPoints.mockResolvedValue([]);
@@ -158,15 +184,63 @@ describe("YorkieEventService", () => {
 			type: DocumentEventType.DocumentRootChanged,
 			attributes: {
 				key: "doc-key",
-				issuedAt: "2026-01-20T11:00:00.000Z",
+				issuedAt: "2026-01-20T12:00:00.000Z",
+			},
+		});
+		await service.handleDocumentEvent({
+			type: DocumentEventType.DocumentRootChanged,
+			attributes: {
+				key: "doc-key",
+				issuedAt: "2026-01-20T12:05:00.000Z",
 			},
 		});
 
-		expect(prismaService.document.update).not.toHaveBeenCalled();
-		expect(indexingQueueService.scheduleIndexing).not.toHaveBeenCalled();
+		await jest.advanceTimersByTimeAsync(5000);
+
+		expect(prismaService.document.update).toHaveBeenCalledTimes(1);
+		expect(prismaService.document.update).toHaveBeenCalledWith({
+			where: {
+				id: "document-id",
+			},
+			data: {
+				updatedAt: new Date("2026-01-20T12:05:00.000Z"),
+			},
+		});
 	});
 
-	it("should keep updatedAt unchanged for invalid webhook timestamps", async () => {
+	it("should skip outdated updatedAt sync without skipping indexing", async () => {
+		const initialUpdatedAt = new Date("2026-01-20T12:00:00.000Z");
+		prismaService.document.findFirst.mockResolvedValue({
+			id: "document-id",
+			workspaceId: "workspace-id",
+			yorkieDocumentId: "doc-key",
+			updatedAt: initialUpdatedAt,
+		});
+		prismaService.document.findUnique.mockResolvedValue({
+			updatedAt: new Date("2026-01-20T12:10:00.000Z"),
+		});
+		qdrantService.getDocumentPoints.mockResolvedValue([]);
+
+		await service.handleDocumentEvent({
+			type: DocumentEventType.DocumentRootChanged,
+			attributes: {
+				key: "doc-key",
+				issuedAt: "2026-01-20T12:00:00.000Z",
+			},
+		});
+
+		expect(indexingQueueService.scheduleIndexing).toHaveBeenCalledWith(
+			"document-id",
+			"workspace-id",
+			30000
+		);
+
+		await jest.advanceTimersByTimeAsync(5000);
+
+		expect(prismaService.document.update).not.toHaveBeenCalled();
+	});
+
+	it("should ignore invalid webhook timestamps without skipping indexing", async () => {
 		const updatedAt = new Date("2026-01-20T12:00:00.000Z");
 		prismaService.document.findFirst.mockResolvedValue({
 			id: "document-id",
@@ -174,6 +248,7 @@ describe("YorkieEventService", () => {
 			yorkieDocumentId: "doc-key",
 			updatedAt,
 		});
+		qdrantService.getDocumentPoints.mockResolvedValue([]);
 
 		await service.handleDocumentEvent({
 			type: DocumentEventType.DocumentRootChanged,
@@ -183,8 +258,13 @@ describe("YorkieEventService", () => {
 			},
 		});
 
+		expect(indexingQueueService.scheduleIndexing).toHaveBeenCalledWith(
+			"document-id",
+			"workspace-id",
+			30000
+		);
+
 		expect(prismaService.document.update).not.toHaveBeenCalled();
-		expect(indexingQueueService.scheduleIndexing).not.toHaveBeenCalled();
 	});
 
 	it("should skip indexing when the Yorkie document does not map to a CodePair document", async () => {

--- a/packages/backend/src/yorkie/yorkie-event.service.ts
+++ b/packages/backend/src/yorkie/yorkie-event.service.ts
@@ -1,4 +1,5 @@
 import { Injectable, Logger } from "@nestjs/common";
+import { ConfigService } from "@nestjs/config";
 import { PrismaService } from "src/db/prisma.service";
 import { IndexingQueueService } from "src/rag/indexing/indexing-queue.service";
 import { QdrantService } from "src/rag/qdrant/qdrant.service";
@@ -17,7 +18,8 @@ export class YorkieEventService {
 	constructor(
 		private prismaService: PrismaService,
 		private indexingQueueService: IndexingQueueService,
-		private qdrantService: QdrantService
+		private qdrantService: QdrantService,
+		private configService: ConfigService
 	) {}
 
 	/**
@@ -29,9 +31,17 @@ export class YorkieEventService {
 			`Received document event: ${eventDto.type} for document key: ${eventDto.attributes.key}`
 		);
 
+		if (!this.isDocumentSyncEnabled()) {
+			this.logger.log("Document sync is disabled; skipping Yorkie document event");
+			return;
+		}
+
 		switch (eventDto.type) {
 			case DocumentEventType.DocumentRootChanged:
-				await this.handleDocumentChanged(eventDto.attributes.key);
+				await this.handleDocumentChanged(
+					eventDto.attributes.key,
+					eventDto.attributes.issuedAt
+				);
 				break;
 			default:
 				this.logger.warn(`Unknown event type: ${eventDto.type}`);
@@ -42,7 +52,10 @@ export class YorkieEventService {
 	 * Handle document changed event - queue it for indexing
 	 * @param yorkieDocumentKey - Yorkie document key
 	 */
-	private async handleDocumentChanged(yorkieDocumentKey: string): Promise<void> {
+	private async handleDocumentChanged(
+		yorkieDocumentKey: string,
+		issuedAt: string
+	): Promise<void> {
 		try {
 			// Find CodePair document by Yorkie document ID
 			const document = await this.prismaService.document.findFirst({
@@ -62,7 +75,18 @@ export class YorkieEventService {
 				return;
 			}
 
-			this.logger.log(`Found CodePair document ${document.id} to queue for indexing`);
+			const syncedUpdatedAt = this.resolveUpdatedAt(document.updatedAt, issuedAt);
+
+			await this.prismaService.document.update({
+				where: {
+					id: document.id,
+				},
+				data: {
+					updatedAt: syncedUpdatedAt,
+				},
+			});
+
+			this.logger.log(`Synced updatedAt for CodePair document ${document.id}`);
 
 			// Queue document for indexing with appropriate debounce
 			const debounceMs = await this.calculateDebounceTime(document.id);
@@ -79,6 +103,23 @@ export class YorkieEventService {
 			);
 			throw error;
 		}
+	}
+
+	private isDocumentSyncEnabled(): boolean {
+		return this.configService.get("YORKIE_DOCUMENT_SYNC") === "true";
+	}
+
+	private resolveUpdatedAt(currentUpdatedAt: Date, issuedAt: string): Date {
+		const webhookTimestamp = new Date(issuedAt);
+
+		if (Number.isNaN(webhookTimestamp.getTime())) {
+			this.logger.warn(
+				`Invalid issuedAt received from Yorkie webhook: ${issuedAt}. Falling back to current time.`
+			);
+			return new Date();
+		}
+
+		return webhookTimestamp > currentUpdatedAt ? webhookTimestamp : currentUpdatedAt;
 	}
 
 	/**

--- a/packages/backend/src/yorkie/yorkie-event.service.ts
+++ b/packages/backend/src/yorkie/yorkie-event.service.ts
@@ -10,10 +10,15 @@ const DEFAULT_DEBOUNCE_MS = 30000; // 30 seconds
 const LONG_DEBOUNCE_MS = 120000; // 2 minutes
 const MANUAL_DEBOUNCE_MS = 5000; // 5 seconds
 const RECENT_INDEX_THRESHOLD_MINUTES = 10; // 10 minutes
+const UPDATED_AT_SYNC_DEBOUNCE_MS = 5000; // 5 seconds
 
 @Injectable()
 export class YorkieEventService {
 	private readonly logger = new Logger(YorkieEventService.name);
+	private readonly pendingUpdatedAtSyncs = new Map<
+		string,
+		{ issuedAt: Date; timeout: NodeJS.Timeout }
+	>();
 
 	constructor(
 		private prismaService: PrismaService,
@@ -30,11 +35,6 @@ export class YorkieEventService {
 		this.logger.log(
 			`Received document event: ${eventDto.type} for document key: ${eventDto.attributes.key}`
 		);
-
-		if (!this.isDocumentSyncEnabled()) {
-			this.logger.log("Document sync is disabled; skipping Yorkie document event");
-			return;
-		}
 
 		switch (eventDto.type) {
 			case DocumentEventType.DocumentRootChanged:
@@ -75,23 +75,9 @@ export class YorkieEventService {
 				return;
 			}
 
-			const syncedUpdatedAt = this.resolveUpdatedAt(document.updatedAt, issuedAt);
-
-			if (syncedUpdatedAt <= document.updatedAt) {
-				this.logger.log(`Skipping stale Yorkie event for CodePair document ${document.id}`);
-				return;
+			if (this.isDocumentSyncEnabled()) {
+				this.scheduleUpdatedAtSync(document.id, issuedAt);
 			}
-
-			await this.prismaService.document.update({
-				where: {
-					id: document.id,
-				},
-				data: {
-					updatedAt: syncedUpdatedAt,
-				},
-			});
-
-			this.logger.log(`Synced updatedAt for CodePair document ${document.id}`);
 
 			// Queue document for indexing with appropriate debounce
 			const debounceMs = await this.calculateDebounceTime(document.id);
@@ -114,17 +100,85 @@ export class YorkieEventService {
 		return this.configService.get("YORKIE_DOCUMENT_SYNC") === "true";
 	}
 
-	private resolveUpdatedAt(currentUpdatedAt: Date, issuedAt: string): Date {
+	private scheduleUpdatedAtSync(documentId: string, issuedAt: string): void {
 		const webhookTimestamp = new Date(issuedAt);
 
 		if (Number.isNaN(webhookTimestamp.getTime())) {
 			this.logger.warn(
 				`Invalid issuedAt received from Yorkie webhook: ${issuedAt}. Keeping current updatedAt.`
 			);
-			return currentUpdatedAt;
+			return;
 		}
 
-		return webhookTimestamp > currentUpdatedAt ? webhookTimestamp : currentUpdatedAt;
+		const existingSync = this.pendingUpdatedAtSyncs.get(documentId);
+
+		if (existingSync) {
+			clearTimeout(existingSync.timeout);
+		}
+
+		const latestIssuedAt =
+			existingSync && existingSync.issuedAt > webhookTimestamp
+				? existingSync.issuedAt
+				: webhookTimestamp;
+		const timeout = setTimeout(() => {
+			void this.flushUpdatedAtSync(documentId);
+		}, UPDATED_AT_SYNC_DEBOUNCE_MS);
+
+		this.pendingUpdatedAtSyncs.set(documentId, {
+			issuedAt: latestIssuedAt,
+			timeout,
+		});
+	}
+
+	private async flushUpdatedAtSync(documentId: string): Promise<void> {
+		const pendingSync = this.pendingUpdatedAtSyncs.get(documentId);
+
+		if (!pendingSync) {
+			return;
+		}
+
+		this.pendingUpdatedAtSyncs.delete(documentId);
+
+		try {
+			const document = await this.prismaService.document.findUnique({
+				where: {
+					id: documentId,
+				},
+				select: {
+					updatedAt: true,
+				},
+			});
+
+			if (!document) {
+				this.logger.warn(
+					`No CodePair document found while flushing updatedAt sync for ${documentId}`
+				);
+				return;
+			}
+
+			if (pendingSync.issuedAt <= document.updatedAt) {
+				this.logger.log(
+					`Skipping outdated updatedAt sync for CodePair document ${documentId}`
+				);
+				return;
+			}
+
+			await this.prismaService.document.update({
+				where: {
+					id: documentId,
+				},
+				data: {
+					updatedAt: pendingSync.issuedAt,
+				},
+			});
+
+			this.logger.log(`Synced updatedAt for CodePair document ${documentId}`);
+		} catch (error) {
+			this.logger.error(
+				`Error flushing updatedAt sync for document ${documentId}: ${error.message}`,
+				error.stack
+			);
+		}
 	}
 
 	/**

--- a/packages/backend/src/yorkie/yorkie-event.service.ts
+++ b/packages/backend/src/yorkie/yorkie-event.service.ts
@@ -78,9 +78,7 @@ export class YorkieEventService {
 			const syncedUpdatedAt = this.resolveUpdatedAt(document.updatedAt, issuedAt);
 
 			if (syncedUpdatedAt <= document.updatedAt) {
-				this.logger.log(
-					`Skipping stale Yorkie event for CodePair document ${document.id}`
-				);
+				this.logger.log(`Skipping stale Yorkie event for CodePair document ${document.id}`);
 				return;
 			}
 

--- a/packages/backend/src/yorkie/yorkie-event.service.ts
+++ b/packages/backend/src/yorkie/yorkie-event.service.ts
@@ -77,6 +77,13 @@ export class YorkieEventService {
 
 			const syncedUpdatedAt = this.resolveUpdatedAt(document.updatedAt, issuedAt);
 
+			if (syncedUpdatedAt <= document.updatedAt) {
+				this.logger.log(
+					`Skipping stale Yorkie event for CodePair document ${document.id}`
+				);
+				return;
+			}
+
 			await this.prismaService.document.update({
 				where: {
 					id: document.id,
@@ -114,9 +121,9 @@ export class YorkieEventService {
 
 		if (Number.isNaN(webhookTimestamp.getTime())) {
 			this.logger.warn(
-				`Invalid issuedAt received from Yorkie webhook: ${issuedAt}. Falling back to current time.`
+				`Invalid issuedAt received from Yorkie webhook: ${issuedAt}. Keeping current updatedAt.`
 			);
-			return new Date();
+			return currentUpdatedAt;
 		}
 
 		return webhookTimestamp > currentUpdatedAt ? webhookTimestamp : currentUpdatedAt;

--- a/packages/backend/src/yorkie/yorkie-event.service.ts
+++ b/packages/backend/src/yorkie/yorkie-event.service.ts
@@ -65,8 +65,6 @@ export class YorkieEventService {
 				select: {
 					id: true,
 					workspaceId: true,
-					yorkieDocumentId: true,
-					updatedAt: true,
 				},
 			});
 

--- a/packages/frontend/src/features/settings/index.ts
+++ b/packages/frontend/src/features/settings/index.ts
@@ -16,6 +16,7 @@ export type { ConfigState } from "./store/configSlice";
 export { default as featureSettingReducer } from "./store/featureSettingSlice";
 export {
 	setYorkieIntelligence,
+	setDocumentSync,
 	setFileUpload,
 	selectFeatureSetting,
 	featureSettingSlice,

--- a/packages/frontend/src/features/settings/store/featureSettingSlice.ts
+++ b/packages/frontend/src/features/settings/store/featureSettingSlice.ts
@@ -17,13 +17,19 @@ interface FileUploadSetting {
 	enable: boolean;
 }
 
+interface DocumentSyncSetting {
+	enable: boolean;
+}
+
 export interface FeatureSettingState {
 	yorkieIntelligence: YorkieIntelligenceSetting | null;
+	documentSync: DocumentSyncSetting | null;
 	fileUpload: FileUploadSetting | null;
 }
 
 const initialState: FeatureSettingState = {
 	yorkieIntelligence: null,
+	documentSync: null,
 	fileUpload: null,
 };
 
@@ -34,13 +40,17 @@ export const featureSettingSlice = createSlice({
 		setYorkieIntelligence: (state, action: PayloadAction<YorkieIntelligenceSetting>) => {
 			state.yorkieIntelligence = action.payload;
 		},
+		setDocumentSync: (state, action: PayloadAction<DocumentSyncSetting>) => {
+			state.documentSync = action.payload;
+		},
 		setFileUpload: (state, action: PayloadAction<FileUploadSetting>) => {
 			state.fileUpload = action.payload;
 		},
 	},
 });
 
-export const { setYorkieIntelligence, setFileUpload } = featureSettingSlice.actions;
+export const { setYorkieIntelligence, setDocumentSync, setFileUpload } =
+	featureSettingSlice.actions;
 
 export const selectFeatureSetting = (state: RootState) => state.featureSetting;
 
@@ -49,6 +59,7 @@ export const selectFeatureSetting = (state: RootState) => state.featureSetting;
  *
  *  * This slice handles:
  * - `yorkieIntelligence`: Settings for the Yorkie Intelligence feature
+ * - `documentSync`: Settings for Yorkie document state synchronization
  * - `fileUpload`: Settings for file upload functionality
  */
 const reducer = featureSettingSlice.reducer;

--- a/packages/frontend/src/hooks/api/settings.ts
+++ b/packages/frontend/src/hooks/api/settings.ts
@@ -4,6 +4,7 @@ import { useEffect } from "react";
 import { useDispatch, useSelector } from "react-redux";
 import {
 	selectFeatureSetting,
+	setDocumentSync,
 	setFileUpload,
 	setYorkieIntelligence,
 } from "../../features/settings";
@@ -20,6 +21,7 @@ export const useGetSettingsQuery = () => {
 		queryKey: generateGetSettingsQueryKey(),
 		enabled:
 			featureSettingStore.yorkieIntelligence === null &&
+			featureSettingStore.documentSync === null &&
 			featureSettingStore.fileUpload === null,
 		queryFn: async () => {
 			const res = await axios.get<GetSettingsResponse>("/settings");
@@ -33,6 +35,7 @@ export const useGetSettingsQuery = () => {
 
 		const data = query.data;
 		dispatch(setYorkieIntelligence(data.yorkieIntelligence));
+		dispatch(setDocumentSync(data.documentSync));
 		dispatch(setFileUpload(data.fileUpload));
 	}, [dispatch, query.data, query.isSuccess]);
 

--- a/packages/frontend/src/hooks/api/types/settings.d.ts
+++ b/packages/frontend/src/hooks/api/types/settings.d.ts
@@ -13,8 +13,14 @@ class FileUploadSetting {
 	enable: boolean;
 }
 
+class DocumentSyncSetting {
+	enable: boolean;
+}
+
 export class GetSettingsResponse {
 	yorkieIntelligence: YorkieIntelligenceSetting;
+
+	documentSync: DocumentSyncSetting;
 
 	fileUpload: FileUploadSetting;
 }


### PR DESCRIPTION
## Summary
- sync document updatedAt from Yorkie DocRootChanged webhook events
- gate Yorkie document syncing behind a documentSync setting and YORKIE_DOCUMENT_SYNC
- add coverage for webhook sync behavior and settings exposure

## Testing
- `COREPACK_HOME=/tmp/corepack PNPM_HOME=/tmp/pnpm corepack pnpm exec jest src/yorkie/yorkie-event.service.spec.ts src/settings/settings.service.spec.ts --runInBand`

## Notes
- a broad `jest --runInBand` run in `packages/backend` still hits existing unrelated failures, including env-dependent Prisma tests that require `DATABASE_URL` and a pre-existing failure in `src/yorkie/yorkie-admin.service.spec.ts`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a document sync setting with enable/disable control; when enabled, webhook-driven syncs coalesce rapid events, debounce updates, and ignore outdated or invalid timestamps while still triggering indexing.

* **Documentation**
  * Updated development setup to include a Yorkie document syncing configuration step in the Full Stack Development Mode instructions.

* **Tests**
  * Expanded tests for settings and document event handling covering sync on/off, debounce/coalescing, timestamp validation, and related behaviors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->