### PR TITLE
Fix Yorkie auth webhook failures and bump SDK to 0.7.12

### DIFF
--- a/packages/backend/prisma/schema.prisma
+++ b/packages/backend/prisma/schema.prisma
@@ -61,6 +61,7 @@ model Document {
   documentSharingTokenList DocumentSharingToken[]
   intelligenceLogList      IntelligenceLog[]
 
+  @@index([yorkieDocumentId])
   @@map("documents")
 }
 

--- a/packages/backend/src/check/check.service.spec.ts
+++ b/packages/backend/src/check/check.service.spec.ts
@@ -1,18 +1,89 @@
+import { ForbiddenException } from "@nestjs/common";
+import { JwtService } from "@nestjs/jwt";
 import { Test, TestingModule } from "@nestjs/testing";
+import { PrismaService } from "src/db/prisma.service";
 import { CheckService } from "./check.service";
+import { CheckYorkieDto, Verb, YorkieMethod } from "./dto/check-yorkie.dto";
 
 describe("CheckService", () => {
 	let service: CheckService;
 
+	const prismaService = {
+		document: { findFirst: jest.fn() },
+		documentSharingToken: { findFirst: jest.fn() },
+	};
+	const jwtService = { verify: jest.fn() };
+
 	beforeEach(async () => {
 		const module: TestingModule = await Test.createTestingModule({
-			providers: [CheckService],
+			providers: [
+				CheckService,
+				{ provide: PrismaService, useValue: prismaService },
+				{ provide: JwtService, useValue: jwtService },
+			],
 		}).compile();
 
 		service = module.get<CheckService>(CheckService);
+		jest.clearAllMocks();
 	});
 
 	it("should be defined", () => {
 		expect(service).toBeDefined();
+	});
+
+	describe("checkYorkie", () => {
+		// Yorkie's unified `Watch` RPC verifies access before subscribing to any
+		// resource, so it carries no document attribute. It must pass through
+		// instead of crashing while reading a document key.
+		it.each([YorkieMethod.ActivateClient, YorkieMethod.DeactivateClient, YorkieMethod.Watch])(
+			"passes through %s without a document attribute",
+			async (method) => {
+				const dto: CheckYorkieDto = {
+					token: "default:token",
+					method,
+					attributes: [],
+				};
+
+				await expect(service.checkYorkie(dto)).resolves.toEqual({
+					allowed: true,
+					reason: `Pass ${method} method`,
+				});
+			}
+		);
+
+		it("rejects a document-scoped method without an attribute instead of throwing", async () => {
+			const dto: CheckYorkieDto = {
+				token: "default:token",
+				method: YorkieMethod.AttachDocument,
+				attributes: [],
+			};
+
+			await expect(service.checkYorkie(dto)).rejects.toBeInstanceOf(ForbiddenException);
+		});
+
+		it("does not crash when the token is missing", async () => {
+			const dto = {
+				method: YorkieMethod.AttachDocument,
+				attributes: [{ key: "doc-1", verb: Verb.rw }],
+			} as unknown as CheckYorkieDto;
+
+			await expect(service.checkYorkie(dto)).rejects.toBeInstanceOf(ForbiddenException);
+		});
+
+		it("allows a default token that owns the document", async () => {
+			jwtService.verify.mockReturnValue({ sub: "user-1" });
+			prismaService.document.findFirst.mockResolvedValue({ id: "doc-object-id" });
+
+			const dto: CheckYorkieDto = {
+				token: "default:jwt",
+				method: YorkieMethod.AttachDocument,
+				attributes: [{ key: "doc-1", verb: Verb.rw }],
+			};
+
+			await expect(service.checkYorkie(dto)).resolves.toEqual({
+				allowed: true,
+				reason: "Valid token",
+			});
+		});
 	});
 });

--- a/packages/backend/src/check/check.service.ts
+++ b/packages/backend/src/check/check.service.ts
@@ -7,6 +7,14 @@ import { CheckYorkieDto, YorkieMethod } from "./dto/check-yorkie.dto";
 import { CheckNameConflicReponse } from "./types/check-name-conflict-response.type";
 import { CheckYorkieResponse } from "./types/check-yorkie-response.type";
 
+// Methods that are not scoped to a single document and therefore have no
+// document attribute to authorize against.
+const PASS_THROUGH_METHODS: ReadonlyArray<YorkieMethod> = [
+	YorkieMethod.ActivateClient,
+	YorkieMethod.DeactivateClient,
+	YorkieMethod.Watch,
+];
+
 @Injectable()
 export class CheckService {
 	constructor(
@@ -33,21 +41,28 @@ export class CheckService {
 	}
 
 	async checkYorkie(checkYorkieDto: CheckYorkieDto): Promise<CheckYorkieResponse> {
-		const [type, token] = checkYorkieDto.token.split(":");
-
-		// In `ActivateClient`, `DeactivateClient` methods, the `checkYorkieDto.attributes` is empty.
-		if (
-			[YorkieMethod.ActivateClient, YorkieMethod.DeactivateClient].includes(
-				checkYorkieDto.method
-			)
-		) {
+		// These methods are not scoped to a single document, so there is no
+		// document attribute to authorize against. `ActivateClient` and
+		// `DeactivateClient` operate at the client level, and Yorkie's unified
+		// `Watch` RPC verifies access before subscribing to any resource, so it
+		// carries no document attribute either. Pass them through.
+		if (PASS_THROUGH_METHODS.includes(checkYorkieDto.method)) {
 			return {
 				allowed: true,
 				reason: `Pass ${checkYorkieDto.method} method`,
 			};
 		}
 
-		const { key: yorkieDocumentId } = checkYorkieDto.attributes?.[0];
+		const [type, token] = (checkYorkieDto.token ?? "").split(":");
+
+		const yorkieDocumentId = checkYorkieDto.attributes?.[0]?.key;
+		if (!yorkieDocumentId) {
+			throw new ForbiddenException({
+				allowed: false,
+				reason: "Missing document attribute",
+			});
+		}
+
 		if (type == "default") {
 			await this.checkDefaultAccessToken(yorkieDocumentId, token);
 		} else if (type == "share") {

--- a/packages/backend/src/check/dto/check-yorkie.dto.ts
+++ b/packages/backend/src/check/dto/check-yorkie.dto.ts
@@ -10,7 +10,7 @@ export enum YorkieMethod {
 	"DeactivateClient" = "DeactivateClient",
 	"AttachDocument" = "AttachDocument",
 	"DetachDocument" = "DetachDocument",
-	"WatchDocuments" = "WatchDocuments",
+	"Watch" = "Watch",
 	"PushPull" = "PushPull",
 }
 

--- a/packages/codemirror/package.json
+++ b/packages/codemirror/package.json
@@ -20,7 +20,7 @@
 		"@uiw/codemirror-extensions-basic-setup": "^4.25.4",
 		"@uiw/codemirror-theme-xcode": "^4.25.4",
 		"@vscode/markdown-it-katex": "^1.1.2",
-		"@yorkie-js/sdk": "0.7.7",
+		"@yorkie-js/sdk": "0.7.12",
 		"codemirror": "^6.0.2",
 		"codemirror-markdown-commands": "^0.0.3",
 		"codemirror-markdown-slug": "^0.0.3",

--- a/packages/frontend/package.json
+++ b/packages/frontend/package.json
@@ -42,7 +42,7 @@
 		"@uiw/codemirror-theme-xcode": "^4.25.4",
 		"@uiw/react-markdown-preview": "^5.1.5",
 		"@vscode/markdown-it-katex": "^1.1.2",
-		"@yorkie-js/sdk": "0.7.7",
+		"@yorkie-js/sdk": "0.7.12",
 		"axios": "^1.13.2",
 		"browser-image-resizer": "^2.4.1",
 		"clipboardy": "^4.0.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -221,8 +221,8 @@ importers:
         specifier: ^1.1.2
         version: 1.1.2
       '@yorkie-js/sdk':
-        specifier: 0.7.7
-        version: 0.7.7
+        specifier: 0.7.12
+        version: 0.7.12
       codemirror:
         specifier: ^6.0.2
         version: 6.0.2
@@ -390,8 +390,8 @@ importers:
         specifier: ^1.1.2
         version: 1.1.2
       '@yorkie-js/sdk':
-        specifier: 0.7.7
-        version: 0.7.7
+        specifier: 0.7.12
+        version: 0.7.12
       axios:
         specifier: ^1.13.2
         version: 1.13.2(debug@4.4.3)
@@ -4093,12 +4093,12 @@ packages:
   '@xtuc/long@4.2.2':
     resolution: {integrity: sha512-NuHqBY1PB/D8xU6s/thBgOAiAP7HOYDQ32+BFZILJ8ivkUkAHQnWfn6WhL79Owj1qmUnoN/YPhktdIoucipkAQ==}
 
-  '@yorkie-js/schema@0.7.7':
-    resolution: {integrity: sha512-SKZHBE/yjOwF4v52J08PInxpKnOP/Y3tN8tDUbhjpG6bY/XbJZn1Ss6SNItLkUsvhW9oEz3Bb/9iSyoiO8D8HQ==}
+  '@yorkie-js/schema@0.7.12':
+    resolution: {integrity: sha512-lZzgK6o4AV3l6KeeVDbL3LKzxwfiVTGJBa4plI2ZfOlnct4iyh6jbzDso0XdUHmhksEpU1KPmTMlqXDTLSG/8w==}
 
-  '@yorkie-js/sdk@0.7.7':
-    resolution: {integrity: sha512-YJlH6SDQgmdfyBv7d/ZkIvLmYfy5YhxEu0h+XYqGNM4ElHH7x1MDBNuxEwUDIQNhKUCV/ID0lANnaTlG3U7Peg==}
-    engines: {node: '>=18.0.0', npm: '>=7.1.0', pnpm: '>=9.6.0'}
+  '@yorkie-js/sdk@0.7.12':
+    resolution: {integrity: sha512-37H6SfBOrLEd5RRAzv9CDHf275GwT+l9nihEbKOU4+T4+Hd5CYFGgioGMf1aDL0j2rvdcmBFlNiQHbqkSlfURA==}
+    engines: {node: ^20.19.0 || >=22.12.0, npm: '>=7.1.0', pnpm: '>=9.6.0'}
 
   abbrev@3.0.1:
     resolution: {integrity: sha512-AO2ac6pjRB3SJmGJo+v5/aK6Omggp6fsLrs6wN9bd35ulu4cCwaAU9+7ZhXjeqHVkaHThLuzH0nZr0YpCDhygg==}
@@ -5859,7 +5859,7 @@ packages:
 
   glob@7.2.3:
     resolution: {integrity: sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==}
-    deprecated: Glob versions prior to v9 are no longer supported
+    deprecated: Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me
 
   glob@9.3.5:
     resolution: {integrity: sha512-e1LleDykUz2Iu+MTYdkSsuWX8lvAjAcs0Xef0lNIu0S2wOAzuTxCJtcd9S3cijlwYF18EsU3rzb8jPVobxDh9Q==}
@@ -13447,14 +13447,14 @@ snapshots:
 
   '@xtuc/long@4.2.2': {}
 
-  '@yorkie-js/schema@0.7.7': {}
+  '@yorkie-js/schema@0.7.12': {}
 
-  '@yorkie-js/sdk@0.7.7':
+  '@yorkie-js/sdk@0.7.12':
     dependencies:
       '@bufbuild/protobuf': 2.10.2
       '@connectrpc/connect': 2.1.1(@bufbuild/protobuf@2.10.2)
       '@connectrpc/connect-web': 2.1.1(@bufbuild/protobuf@2.10.2)(@connectrpc/connect@2.1.1(@bufbuild/protobuf@2.10.2))
-      '@yorkie-js/schema': 0.7.7
+      '@yorkie-js/schema': 0.7.12
 
   abbrev@3.0.1: {}
 


### PR DESCRIPTION
## Summary

The Yorkie project's auth webhook (`/check/yorkie`) caused **100% connection failures** whenever it was enabled. Investigation against the production cluster found two independent root causes, both fixed here, plus an SDK bump to match the server.

### 1. AttachDocument timed out (unindexed COLLSCAN)

`checkYorkie` → `checkDefaultAccessToken` runs `document.findFirst({ where: { yorkieDocumentId, ... } })`, but `documents.yorkie_document_id` had **no index**. On the production collection (~3.7k docs) this was a `COLLSCAN` that exceeded Yorkie's **3s auth-webhook deadline**, so every attach was denied with `context deadline exceeded`.

- Verified via `explain`: `COLLSCAN` → after adding the index, `FETCH → IXSCAN`, `docsExamined 3753 → 0`, `~2ms`.
- Added `@@index([yorkieDocumentId])` to the Prisma schema.

> Note: the index was already created directly on the production DB to restore service. This schema change makes it permanent so `prisma db push`/migrations don't drop it.

### 2. Watch crashed with a 500 (stale enum + missing attribute)

Yorkie unified `WatchDocument`/`WatchChannel` into a single **`Watch`** RPC ([yorkie #1666](https://github.com/yorkie-team/yorkie/pull/1666)) that verifies access **before** subscribing to any resource, so it sends **no document attribute**. The handler did `const { key } = checkYorkieDto.attributes?.[0]` → `TypeError: Cannot destructure property 'key' of undefined` → **500**, which Yorkie retried for ~21s before failing the Watch stream. The `YorkieMethod` enum also still had the long-obsolete `WatchDocuments` (plural).

- Renamed `WatchDocuments` → `Watch`.
- Pass `Watch` through alongside `ActivateClient`/`DeactivateClient` (no document to authorize against).
- Reject a missing token/attribute with `ForbiddenException` instead of throwing a 500.

### 3. Bump `@yorkie-js/sdk` to 0.7.12

Aligns the client SDK (was 0.7.7) with the 0.7.12 server in production, unified across `frontend` and `codemirror`.

## Test plan

- `pnpm backend test` — added `check.service` specs covering `Watch` pass-through, missing attribute → `Forbidden`, missing token → no crash, and the happy path (7 passing).
- `pnpm backend build`, `pnpm frontend build` (SDK 0.7.12 typechecks), `pnpm lint` all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved document access checks for Yorkie-related actions, including watch requests and missing-token handling.

* **Bug Fixes**
  * Prevented failures when a token is absent and now return a clear access error instead.
  * Added a check for missing document attributes to block invalid document-scoped requests.
  * Updated document lookup performance with a new index for faster access by Yorkie document ID.

* **Updates**
  * Bumped the Yorkie SDK version used by the app and editor integration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->