### PR TITLE
Update CHANGELOG.md for v0.2.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ and CodePair adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ## [Unreleased]
 
+## [0.2.3] - 2026-07-02
+
+### Fixed
+
+- Fix Yorkie auth webhook failures and bump up @yorkie-js/sdk to v0.7.12 by @hackerwins in https://github.com/yorkie-team/codepair/pull/605
+
+### Changed
+
+- Align .nvmrc with supported Node.js versions by @hyunji1117 in https://github.com/yorkie-team/codepair/pull/603
+
 ## [0.2.2] - 2026-04-27
 
 ### Changed

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "codepair",
-  "version": "0.2.2",
+  "version": "0.2.3",
   "description": "Build your own AI-powered collaborative markdown editor in just 5 minutes",
   "keywords": [],
   "author": "yorkie-team",

--- a/packages/backend/package.json
+++ b/packages/backend/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@codepair/backend",
-	"version": "0.2.2",
+	"version": "0.2.3",
 	"description": "CodePair Backend",
 	"author": "yorkie-team",
 	"license": "Apache-2.0",

--- a/packages/frontend/package.json
+++ b/packages/frontend/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@codepair/frontend",
-	"version": "0.2.2",
+	"version": "0.2.3",
 	"description": "CodePair Frontend",
 	"type": "module",
 	"author": "yorkie-team",


### PR DESCRIPTION
Prepare the v0.2.3 release.

- Bump `version` to 0.2.3 in the root, `backend`, and `frontend` `package.json`.
- Add the 0.2.3 section to `CHANGELOG.md`.

### Included since v0.2.2

- Fix Yorkie auth webhook failures and bump `@yorkie-js/sdk` to v0.7.12 (#605)
- Align .nvmrc with supported Node.js versions (#603)

After merge, publish the `v0.2.3` GitHub Release to trigger the Docker Hub image build (`docker-publish.yaml`) and GitHub Pages deploy (`gh_pages.yaml`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Fixed**
  * Resolved authentication webhook failures.
  * Updated a core SDK to a newer version for improved reliability.

* **Changed**
  * Aligned the project’s Node.js version guidance with supported versions.

* **Chores**
  * Bumped the release version to **0.2.3** across the project.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->