### PR TITLE
Add CodePair developer setup CLI

### DIFF
--- a/.github/workflows/ci_cli.yaml
+++ b/.github/workflows/ci_cli.yaml
@@ -1,0 +1,127 @@
+name: CI CLI
+on:
+  push:
+    branches: main
+    paths:
+      - ".github/workflows/ci_cli.yaml"
+      - "packages/backend/.env.example"
+      - "packages/backend/docker/docker-compose*.yml"
+      - "packages/cli/**"
+      - "packages/frontend/.env.example"
+      - "package.json"
+      - "pnpm-lock.yaml"
+      - "pnpm-workspace.yaml"
+      - "scripts/setup-yorkie-webhook.js"
+  pull_request:
+    branches:
+      - main
+    paths:
+      - ".github/workflows/ci_cli.yaml"
+      - "packages/backend/.env.example"
+      - "packages/backend/docker/docker-compose*.yml"
+      - "packages/cli/**"
+      - "packages/frontend/.env.example"
+      - "package.json"
+      - "pnpm-lock.yaml"
+      - "pnpm-workspace.yaml"
+      - "scripts/setup-yorkie-webhook.js"
+
+permissions:
+  contents: read
+
+jobs:
+  test:
+    name: Node.js ${{ matrix.node-version }} on ${{ matrix.os }}
+    runs-on: ${{ matrix.os }}
+    timeout-minutes: 20
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - os: ubuntu-latest
+            node-version: 22.x
+            integration: true
+          - os: macos-latest
+            node-version: 20.x
+            integration: false
+          - os: windows-latest
+            node-version: 24.x
+            integration: false
+    steps:
+      - name: Checkout 🛎️
+        uses: actions/checkout@v4
+      - name: Install pnpm
+        uses: pnpm/action-setup@v4
+      - name: Use Node.js ${{ matrix.node-version }}
+        uses: actions/setup-node@v4
+        with:
+          node-version: ${{ matrix.node-version }}
+          cache: "pnpm"
+      - name: Install packages
+        run: pnpm install --frozen-lockfile --filter @codepair/cli --ignore-scripts
+      - name: Prettier
+        run: pnpm --filter=@codepair/cli format:check
+      - name: Integration file formatting
+        run: >-
+          pnpm --filter=@codepair/cli exec prettier --check
+          ../../README.md
+          ../../docs/design/cli.md
+          ../../scripts/setup-yorkie-webhook.js
+          ../../.github/workflows/ci_cli.yaml
+      - name: Lint
+        run: pnpm --filter=@codepair/cli lint
+      - name: Typecheck
+        run: pnpm --filter=@codepair/cli typecheck
+      - name: Unit tests
+        run: pnpm --filter=@codepair/cli test
+      - name: End-to-end tests
+        run: pnpm --filter=@codepair/cli test:e2e
+      - name: Check package contents
+        run: pnpm --filter=@codepair/cli pack:check
+      - name: Validate Docker Compose files
+        if: matrix.integration
+        run: |
+          docker compose -f packages/backend/docker/docker-compose.yml config --quiet
+          docker compose -f packages/backend/docker/docker-compose-full.yml config --quiet
+      - name: Install Yorkie CLI
+        if: matrix.integration
+        shell: bash
+        run: |
+          archive="$RUNNER_TEMP/yorkie-v0.7.12-linux-amd64.tar.gz"
+          install_dir="$RUNNER_TEMP/yorkie-cli"
+          curl --fail --location --retry 3 \
+            --output "$archive" \
+            https://github.com/yorkie-team/yorkie/releases/download/v0.7.12/yorkie-v0.7.12-linux-amd64.tar.gz
+          echo "a111367beeee9925248c506c11a8a8c9cb8dca0b48c79d542dbce6b66f88a4d9  $archive" \
+            | sha256sum --check
+          mkdir -p "$install_dir"
+          tar --extract --gzip --file "$archive" --directory "$install_dir" \
+            --strip-components=1
+          echo "$install_dir" >> "$GITHUB_PATH"
+      - name: Start Yorkie server
+        if: matrix.integration
+        shell: bash
+        run: |
+          docker run --detach --name codepair-cli-yorkie \
+            --publish 18080:8080 \
+            yorkieteam/yorkie@sha256:f20f8d3604397156883bda4aa0e2951e5e537656af9a59fd1f34f591ac8206f3 \
+            server --pprof-enabled
+          for attempt in {1..30}; do
+            if (echo > /dev/tcp/127.0.0.1/18080) >/dev/null 2>&1; then
+              exit 0
+            fi
+            sleep 1
+          done
+          docker logs codepair-cli-yorkie
+          exit 1
+      - name: Real Yorkie integration test
+        if: matrix.integration
+        env:
+          CODEPAIR_YORKIE_RPC_ADDR: 127.0.0.1:18080
+        run: pnpm --filter=@codepair/cli test:integration
+      - name: Yorkie logs
+        if: ${{ always() && matrix.integration }}
+        run: docker logs codepair-cli-yorkie || true
+      - name: Stop Yorkie server
+        if: ${{ always() && matrix.integration }}
+        run: docker rm --force codepair-cli-yorkie || true

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -4,6 +4,7 @@ LINT_FRONTEND=false
 LINT_BACKEND=false
 LINT_UI=false
 LINT_CODEMIRROR=false
+LINT_CLI=false
 
 for FILE in $CHANGED_FILES; do
   if [[ "$FILE" =~ ^packages/frontend/ ]]; then
@@ -14,6 +15,8 @@ for FILE in $CHANGED_FILES; do
     LINT_UI=true
   elif [[ "$FILE" =~ ^packages/codemirror/ ]]; then
     LINT_CODEMIRROR=true
+  elif [[ "$FILE" =~ ^packages/cli/ ]]; then
+    LINT_CLI=true
   fi
 done
 
@@ -56,6 +59,17 @@ if [ "$LINT_CODEMIRROR" = true ]; then
   npx lint-staged
   if [ $? -ne 0 ]; then
     echo "CodeMirror Linting & Formatting failed. Commit aborted."
+    exit 1
+  fi
+  cd ../..
+fi
+
+if [ "$LINT_CLI" = true ]; then
+  echo "Changes detected in cli. Linting & Formatting cli..."
+  cd packages/cli
+  npx lint-staged
+  if [ $? -ne 0 ]; then
+    echo "CLI Linting & Formatting failed. Commit aborted."
     exit 1
   fi
   cd ../..

--- a/MAINTAINING.md
+++ b/MAINTAINING.md
@@ -5,7 +5,7 @@
 ### 1. Update the version number.
 
 - Update the `version` field in the root `package.json` file to reflect the overall version of the monorepo.
-- Also, update `version` fields in the [`frontend` package.json](https://github.com/yorkie-team/codepair/blob/1f10dff1d9c253f921ba136c812383fbb292078f/frontend/package.json#L3) and [`backend` package.json](https://github.com/yorkie-team/codepair/blob/1f10dff1d9c253f921ba136c812383fbb292078f/backend/package.json#L3).
+- Also update the `version` fields in the frontend, backend, and private CLI package manifests.
 
 ### 2. Write changelog of this version in [CHANGELOG.md](https://github.com/yorkie-team/codepair/blob/main/CHANGELOG.md).
 

--- a/README.md
+++ b/README.md
@@ -29,11 +29,44 @@ This repository contains multiple packages that make up our project, organized a
 - **`@codepair/backend`**: NestJS API server. See [packages/backend/README.md](packages/backend/README.md) for details.
 - **`@codepair/codemirror`**: CodeMirror 6 editor with Yorkie sync, toolbar, preview. Self-contained vertical slice.
 - **`@codepair/ui`**: Shared types (`EditorPort`, `EditorModeType`, `PresenceInfo`) and pure UI components.
+- **`@codepair/cli`**: Node.js CLI for local CodePair setup and Yorkie webhook configuration.
 
 ## Node.js Version Support
 
 - **Supported:** **20.x (LTS)**, **22.x (Active LTS)**, **24.x (Current)**
 - **Dropped:** **18.x** (End-of-life)
+
+## Command-Line Interface
+
+After installing the workspace dependencies, run the CLI from the repository root:
+
+```bash
+pnpm cli --help
+pnpm cli setup yorkie
+pnpm cli doctor
+```
+
+The setup command creates or reuses the local Yorkie project, configures its event webhook, and
+synchronizes the Yorkie addresses and project keys in the development environment files. Its
+default webhook URL is `http://host.docker.internal:3000/yorkie/document-events`, which lets the
+Yorkie container reach the backend through its published port. Override it when your backend is
+reachable elsewhere:
+
+```bash
+pnpm cli setup yorkie --webhook-url http://your-backend:3000/yorkie/document-events
+```
+
+This workflow is intended for **Full Stack Development Mode**, where the backend runs on the host.
+Frontend-only mode uses the services configured directly in `docker-compose-full.yml`.
+
+For backward compatibility, the non-interactive webhook setup command remains available:
+
+```bash
+pnpm setup:webhook
+```
+
+This delegates to the CLI non-interactively while retaining the legacy command's defaults. New
+automation should call `pnpm cli setup yorkie --yes` directly.
 
 ## Getting Started with Development
 
@@ -41,7 +74,8 @@ This repository contains multiple packages that make up our project, organized a
 
 For the Social Login feature, you need to obtain a GitHub OAuth key before running the project. Please refer to [this document](./docs/1_Set_Up_GitHub_OAuth_Key.md) for guidance.
 
-After completing this step, you should have the `GITHUB_CLIENT_ID` and `GITHUB_CLIENT_SECRET` values.
+After completing this step, you should have the `GITHUB_CLIENT_ID` and `GITHUB_CLIENT_SECRET`
+values.
 
 ### 2. Choose Running Mode
 
@@ -85,16 +119,20 @@ We offer two options. Choose the one that best suits your needs:
 
 ### 3-2. Full Stack Development Mode
 
-1. Update your `GITHUB_CLIENT_ID` and `GITHUB_CLIENT_SECRET` to `./packages/backend/.env.development`.
+1. Copy the environment examples if they are missing, then add your GitHub OAuth values to
+   `./packages/backend/.env.development`.
 
    ```bash
-   vi ./packages/backend/.env.development
+   cp -n packages/backend/.env.example packages/backend/.env.development
+   cp -n packages/frontend/.env.example packages/frontend/.env.development
 
-   # In the file, update the following values:
-   # GITHUB_CLIENT_ID, GITHUB_CLIENT_SECRET
+   # Edit packages/backend/.env.development:
    GITHUB_CLIENT_ID=your_github_client_id_here
    GITHUB_CLIENT_SECRET=your_github_client_secret_here
    ```
+
+   The setup CLI only updates the Yorkie addresses and project keys. It preserves OAuth
+   credentials, JWT settings, and every other existing value.
 
 2. Run `./packages/backend/docker/docker-compose.yml`.
 
@@ -111,7 +149,7 @@ We offer two options. Choose the one that best suits your needs:
 4. Set up the Yorkie webhook:
 
    ```bash
-   pnpm setup:webhook
+   pnpm cli setup yorkie --yes
    ```
 
 5. Run the Backend application and the Frontend application:
@@ -130,6 +168,7 @@ See [CONTRIBUTING](CONTRIBUTING.md) for details on submitting patches and the co
 ## Documentation
 
 - [docs/design/](docs/design/README.md) — Architectural design documents
+- [docs/design/cli.md](docs/design/cli.md) — CLI design and integration
 - [docs/tasks/](docs/tasks/README.md) — Task tracking (active and archived)
 - [docs/editor-port-architecture.md](docs/editor-port-architecture.md) — Editor port architecture overview
 - [packages/frontend/design/](packages/frontend/design/README.md) — Frontend-specific design docs

--- a/docs/design/README.md
+++ b/docs/design/README.md
@@ -4,4 +4,4 @@ New design documents should be based on [TEMPLATE.md](TEMPLATE.md).
 
 ## Contents
 
-(none)
+- [CodePair CLI](cli.md)

--- a/docs/design/cli.md
+++ b/docs/design/cli.md
@@ -1,0 +1,89 @@
+---
+created: 2026-07-15
+updated: 2026-07-15
+tags: [cli, developer-tooling]
+---
+
+# CodePair CLI
+
+## Problem
+
+Local CodePair setup was implemented as a standalone JavaScript script. It was not typed,
+packaged, or easy to validate across the operating systems and Node.js versions that CodePair
+supports. Adding more setup operations to that script would make its command surface and failure
+handling increasingly difficult to maintain.
+
+### Goals
+
+- Provide a typed Node.js CLI in the pnpm workspace.
+- Offer clear setup and diagnostic commands for contributors and automation.
+- Preserve the existing `pnpm setup:webhook` workflow.
+- Validate the built and installed package across the supported Node.js versions and operating systems.
+
+### Non-Goals
+
+- Replace the Yorkie CLI or Yorkie server.
+- Change the frontend or backend runtime architecture.
+- Provide production deployment orchestration.
+
+## Design
+
+The CLI lives in `packages/cli` as `@codepair/cli`. Contributors invoke it from the repository
+root with `pnpm cli <arguments>`, which delegates to the package's development entry point.
+`setup yorkie` owns local Yorkie project and webhook configuration, while `doctor` reports
+toolchain, environment, service, and Yorkie readiness.
+
+The existing `pnpm setup:webhook` command remains a non-interactive compatibility entry point. Its
+root-level wrapper preserves the legacy webhook default and trusted-remote behavior, then delegates
+to the CLI, which is the only implementation of the workflow. New automation should invoke
+`pnpm cli setup yorkie --yes` and opt into any remote plaintext transport explicitly.
+
+When development environment files do not exist, setup seeds them from the checked-in
+`.env.example` files. It then writes only the selected Yorkie addresses and project keys, leaving
+OAuth, JWT, AI provider, and storage settings untouched. The default webhook uses
+`host.docker.internal` so Yorkie running in Docker can reach the backend's published host port;
+`--webhook-url` supports other network layouts.
+
+Commands return `0` on success, `1` for operational or diagnostic failure or an explicit user
+decline, and `2` for invalid usage, safety validation, or a required confirmation in a non-TTY
+environment. Both setup and doctor support structured JSON output so automation does not need to
+parse human-readable messages.
+
+CI pairs Linux, macOS, and Windows with Node.js 22, 20, and 24 respectively, covering every
+supported operating system and Node.js major with three jobs rather than a nine-job Cartesian
+matrix. Each job runs formatting, linting, type checking, unit tests, end-to-end tests, and an
+installed-package smoke test. The Linux job also runs control-plane setup, idempotency, and doctor
+checks against pinned Yorkie CLI and server releases.
+
+### Risks and Mitigation
+
+| Risk                                                      | Mitigation                                                                                    |
+| --------------------------------------------------------- | --------------------------------------------------------------------------------------------- |
+| The compatibility command changes behavior                | Preserve its legacy webhook and plaintext-remote defaults in the wrapper and test both paths. |
+| The CLI works in the workspace but not after packaging    | Install and execute the packed artifact in CI on all supported platforms.                     |
+| Platform-specific process or path behavior regresses      | Run the CLI validation suite on Ubuntu, macOS, and Windows.                                   |
+| A fake Yorkie misses a protocol or configuration mismatch | Run one pinned real-Yorkie integration path on Linux.                                         |
+| The container cannot reach a host backend                 | Add a host gateway mapping and use a container-reachable default webhook URL.                 |
+
+### Design Decisions
+
+| Decision                                             | Reason                                                                                                                                   |
+| ---------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------- |
+| Place the CLI under `packages/cli`                   | The existing `packages/*` workspace glob discovers it without special workspace configuration.                                           |
+| Keep the package private                             | The CLI configures a repository checkout; avoiding an npm release contract keeps ownership within the existing monorepo release process. |
+| Route root commands through the package `dev` script | Contributors can run the TypeScript entry point without a separate root implementation.                                                  |
+| Keep `setup:webhook` as a root alias                 | Existing documentation and automation continue to work.                                                                                  |
+| Test the packed package in CI                        | Source-level tests alone cannot validate binary metadata or installation behavior.                                                       |
+| Use a three-job compatibility matrix                 | It covers each supported OS and Node.js major without nine full workspace installs.                                                      |
+
+## Alternatives Considered
+
+| Alternative                              | Why not                                                                                   |
+| ---------------------------------------- | ----------------------------------------------------------------------------------------- |
+| Extend `scripts/setup-yorkie-webhook.js` | It would keep the setup flow untyped, unpackaged, and difficult to test across platforms. |
+| Put CLI commands in the backend package  | CLI startup and packaging should not depend on the NestJS application lifecycle.          |
+| Remove `pnpm setup:webhook` immediately  | It would break existing contributor workflows and automation without a migration period.  |
+
+## Tasks
+
+No separate execution task document is required for this focused integration.

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "frontend": "pnpm --filter=@codepair/frontend",
     "backend": "pnpm --filter=@codepair/backend",
     "desktop": "pnpm --filter=@codepair/desktop",
+    "cli": "pnpm --filter=@codepair/cli dev",
     "lint": "pnpm run --parallel lint",
     "lint:check": "pnpm run --parallel lint:check",
     "format": "pnpm run --parallel format",

--- a/packages/backend/.env.example
+++ b/packages/backend/.env.example
@@ -1,0 +1,59 @@
+# Database
+DATABASE_URL=mongodb://localhost:27017/codepair
+
+# GitHub OAuth
+# Create an OAuth app with this callback URL, then provide its credentials here or
+# export GITHUB_CLIENT_ID and GITHUB_CLIENT_SECRET before starting the backend.
+GITHUB_CLIENT_ID=
+GITHUB_CLIENT_SECRET=
+GITHUB_CALLBACK_URL=http://localhost:3000/auth/login/github
+GITHUB_AUTHORIZATION_URL=https://github.com/login/oauth/authorize
+GITHUB_TOKEN_URL=https://github.com/login/oauth/access_token
+GITHUB_USER_PROFILE_URL=https://api.github.com/user
+
+# Authentication
+# These development-only placeholders let the local backend start. Replace them
+# before sharing or exposing the environment.
+JWT_ACCESS_TOKEN_SECRET=you_should_change_this_access_token_secret_key_in_production
+JWT_ACCESS_TOKEN_EXPIRATION_TIME=86400
+JWT_REFRESH_TOKEN_SECRET=you_should_change_this_refresh_token_secret_key_in_production
+JWT_REFRESH_TOKEN_EXPIRATION_TIME=604800
+
+# Application URLs
+FRONTEND_BASE_URL=http://localhost:5173
+YORKIE_API_ADDR=http://localhost:8080
+# The setup CLI writes the local Yorkie project secret.
+YORKIE_PROJECT_SECRET_KEY=
+
+# AI provider
+# Set YORKIE_INTELLIGENCE=false to disable AI features.
+YORKIE_INTELLIGENCE=ollama:llama3.2:1b
+OLLAMA_HOST_URL=http://localhost:11434
+
+# OpenAI provider (optional)
+OPENAI_API_KEY=
+OPENAI_BASE_URL=
+
+# OpenAI-compatible provider (optional)
+OPENAI_COMPAT_BASE_URL=
+OPENAI_COMPAT_API_KEY=
+OPENAI_COMPAT_EMBEDDING_MODEL=
+
+# LangSmith tracing (optional)
+LANGCHAIN_TRACING_V2=false
+LANGCHAIN_API_KEY=
+LANGCHAIN_PROJECT=
+
+# Local object storage
+FILE_UPLOAD=minio
+BUCKET_NAME=default-storage
+MINIO_ENDPOINT=http://localhost:9000
+MINIO_ACCESS_KEY=minioadmin
+MINIO_SECRET_KEY=minioadmin
+AWS_REGION=us-east-1
+
+# Local vector database
+QDRANT_URL=http://localhost:6333
+QDRANT_COLLECTION_NAME=document_chunks
+# nomic-embed-text produces 768-dimensional vectors.
+QDRANT_VECTOR_SIZE=768

--- a/packages/backend/docker/docker-compose.yml
+++ b/packages/backend/docker/docker-compose.yml
@@ -3,6 +3,8 @@ services:
         image: "yorkieteam/yorkie:latest"
         command: ["server", "--pprof-enabled"]
         restart: always
+        extra_hosts:
+            - "host.docker.internal:host-gateway"
         ports:
             - "8080:8080"
             - "8081:8081"

--- a/packages/cli/.prettierignore
+++ b/packages/cli/.prettierignore
@@ -1,0 +1,4 @@
+dist
+coverage
+node_modules
+*.tgz

--- a/packages/cli/.prettierrc
+++ b/packages/cli/.prettierrc
@@ -1,0 +1,9 @@
+{
+	"semi": true,
+	"tabWidth": 4,
+	"useTabs": true,
+	"printWidth": 100,
+	"singleQuote": false,
+	"trailingComma": "es5",
+	"bracketSpacing": true
+}

--- a/packages/cli/LICENSE
+++ b/packages/cli/LICENSE
@@ -1,0 +1,201 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -1,0 +1,147 @@
+# @codepair/cli
+
+`@codepair/cli` bootstraps and diagnoses a local
+[CodePair](https://github.com/yorkie-team/codepair) development environment. It is a typed,
+dependency-free Node.js command-line application that owns the webhook setup implementation.
+
+## Requirements
+
+- Node.js 20, 22, or 24
+- pnpm 9
+- Docker with Docker Compose
+- The Yorkie CLI on `PATH`
+- A CodePair checkout
+
+From the repository root, run the development entry point:
+
+```sh
+pnpm cli --help
+```
+
+The packed package exposes an executable named `codepair`:
+
+```sh
+codepair --version
+```
+
+## Set up Yorkie
+
+```sh
+pnpm cli setup yorkie --yes
+```
+
+Setup performs the following operations:
+
+1. Validates the CodePair checkout, transport policy, selected URLs, and Yorkie CLI.
+2. Logs in to Yorkie and creates the selected project if it does not exist.
+3. Configures the `DocumentRootChanged` event webhook and verifies the result.
+4. Seeds missing backend and frontend `.env.development` files from `.env.example`.
+5. Writes the selected Yorkie addresses and project keys without changing unrelated values.
+6. Re-reads the project and environment files to verify the postconditions.
+
+The operation is idempotent. Existing unrelated environment settings and comments are preserved.
+The default webhook is
+`http://host.docker.internal:3000/yorkie/document-events`, which lets Yorkie in Docker reach the
+backend on the host. Override it for a different network layout.
+
+```text
+Usage:
+  codepair setup yorkie [options]
+
+Options:
+  --rpc-addr ADDRESS          Yorkie RPC address (default: localhost:8080)
+  --project NAME             Yorkie project name (default: codepair)
+  --username NAME            Yorkie administrator username (default: admin)
+  --password-stdin           Read the Yorkie password from standard input
+  --webhook-url URL          DocumentRootChanged event webhook URL
+  --backend-env PATH         Backend .env.development path
+  --frontend-env PATH        Frontend .env.development path
+  --secure                   Use TLS; omit Yorkie's --insecure flag
+  --insecure                 Use plaintext transport (the local default)
+  --allow-insecure-remote    Allow plaintext login to a non-loopback host
+  -y, --yes                  Confirm mutations; required when non-interactive
+  --dry-run                  Validate prerequisites and print the mutation plan
+  --root PATH                CodePair repository root
+  --json                     Emit one structured JSON document
+```
+
+The equivalent environment variables are `YORKIE_API_ADDR`, `YORKIE_PROJECT_NAME`,
+`YORKIE_USERNAME`, `YORKIE_PASSWORD`, `WEBHOOK_URL`, `BACKEND_ENV_FILE`, and
+`FRONTEND_ENV_FILE`. For the Yorkie address, precedence is command-line option, process
+environment, matching existing backend/frontend values, then `localhost:8080`. Conflicting
+existing values require an explicit `--rpc-addr`.
+
+For piped password input, combine `--password-stdin` with `--yes`:
+
+```sh
+printf '%s\n' "$YORKIE_PASSWORD" | codepair setup yorkie --yes --password-stdin
+```
+
+PowerShell:
+
+```powershell
+$env:YORKIE_PASSWORD | codepair setup yorkie --yes --password-stdin
+```
+
+Yorkie currently accepts its password through `yorkie login -p`. The CodePair CLI keeps piped
+input out of its own command line and redacts diagnostics, but the child Yorkie process may expose
+the password briefly to same-host process inspection. Run setup only on a trusted development
+machine.
+
+## Diagnose the environment
+
+`doctor` does not change CodePair or Yorkie server state. It checks supported tool versions,
+required environment values, service reachability, and whether the local Yorkie keys and webhook
+match the selected project.
+
+```sh
+codepair doctor
+codepair doctor --scope toolchain
+codepair doctor --strict --json
+```
+
+Scopes are `all`, `toolchain`, `env`, `services`, and `yorkie`. Warnings are informational by
+default; `--strict` treats them as failures. When setup used custom values, pass the matching
+`--rpc-addr`, `--project`, `--webhook-url`, `--backend-env`, or `--frontend-env` options to doctor.
+
+## Automation contract
+
+Both commands accept `--json` and write exactly one JSON document to standard output. The stable
+exit codes are:
+
+| Code | Meaning                                                                     |
+| ---: | --------------------------------------------------------------------------- |
+|  `0` | The command completed successfully.                                         |
+|  `1` | An operation or diagnostic check failed, or the user declined confirmation. |
+|  `2` | Usage or safety validation failed, including missing non-TTY confirmation.  |
+
+Global options (`--root`, `--json`, `--help`, and `--version`) may appear before or after the
+command. JSON mode never opens an interactive prompt; pass `--yes` when a JSON setup invocation
+should mutate the environment.
+
+## Security behavior
+
+- External commands use argument arrays without shell interpolation.
+- Plaintext Yorkie login is refused for non-loopback RPC hosts unless
+  `--allow-insecure-remote` is explicit. Prefer `--secure`.
+- A non-interactive mutation requires `--yes`.
+- Passwords and known secret fields are redacted from diagnostics and JSON.
+- Environment files are replaced atomically and use owner-only permissions where supported.
+- Webhook URLs containing embedded credentials are rejected.
+
+## Package development
+
+Run checks from `packages/cli`:
+
+```sh
+pnpm format:check
+pnpm lint:check
+pnpm typecheck
+pnpm test
+pnpm test:e2e
+pnpm pack:check
+```
+
+`pnpm verify` runs the complete package-local validation sequence. The build removes `dist` before
+compilation so stale files cannot enter a package tarball. CI also runs `test:integration` against
+pinned Yorkie CLI and server releases on Linux.

--- a/packages/cli/eslint.config.mjs
+++ b/packages/cli/eslint.config.mjs
@@ -1,0 +1,29 @@
+import { dirname } from "node:path";
+import { fileURLToPath } from "node:url";
+import typescriptPlugin from "@typescript-eslint/eslint-plugin";
+import typescriptParser from "@typescript-eslint/parser";
+
+const directory = dirname(fileURLToPath(import.meta.url));
+
+export default [
+	{
+		ignores: ["dist/**", "coverage/**"],
+	},
+	{
+		files: ["src/**/*.ts"],
+		languageOptions: {
+			parser: typescriptParser,
+			parserOptions: {
+				project: "./tsconfig.json",
+				tsconfigRootDir: directory,
+			},
+		},
+		plugins: {
+			"@typescript-eslint": typescriptPlugin,
+		},
+		rules: {
+			...typescriptPlugin.configs.recommended.rules,
+			"@typescript-eslint/no-explicit-any": "error",
+		},
+	},
+];

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,0 +1,68 @@
+{
+	"name": "@codepair/cli",
+	"version": "0.2.3",
+	"private": true,
+	"description": "Bootstrap and diagnose a self-hosted CodePair development environment",
+	"keywords": [
+		"codepair",
+		"yorkie",
+		"developer-tools"
+	],
+	"author": "yorkie-team",
+	"license": "Apache-2.0",
+	"homepage": "https://github.com/yorkie-team/codepair#readme",
+	"bugs": {
+		"url": "https://github.com/yorkie-team/codepair/issues"
+	},
+	"repository": {
+		"type": "git",
+		"url": "git+https://github.com/yorkie-team/codepair.git",
+		"directory": "packages/cli"
+	},
+	"type": "module",
+	"bin": {
+		"codepair": "dist/cli.js"
+	},
+	"exports": {
+		"./package.json": "./package.json"
+	},
+	"files": [
+		"dist"
+	],
+	"scripts": {
+		"clean": "node --eval \"require('node:fs').rmSync('dist', { recursive: true, force: true })\"",
+		"build": "pnpm run clean && tsc -p tsconfig.json",
+		"dev": "pnpm run build && node dist/cli.js",
+		"typecheck": "tsc -p tsconfig.json --noEmit",
+		"test": "pnpm run build && node --test test/unit/env-file.test.mjs test/unit/options.test.mjs test/unit/process-services.test.mjs test/unit/url-redact.test.mjs test/unit/yorkie-cli.test.mjs",
+		"test:e2e": "pnpm run build && node --test test/e2e/cli.test.mjs && node --test test/e2e/setup.test.mjs && node --test test/e2e/package.test.mjs",
+		"test:integration": "pnpm run build && node --test test/integration/yorkie.test.mjs",
+		"prepack": "pnpm run build",
+		"pack:check": "npm pack --dry-run",
+		"verify": "pnpm run format:check && pnpm run lint:check && pnpm run typecheck && pnpm run test && pnpm run test:e2e && pnpm run pack:check",
+		"lint": "eslint src --report-unused-disable-directives --max-warnings 0",
+		"lint:check": "eslint src --report-unused-disable-directives --max-warnings 0",
+		"format": "prettier . --write",
+		"format:check": "prettier . --check"
+	},
+	"engines": {
+		"node": "^20 || ^22 || ^24"
+	},
+	"lint-staged": {
+		"*.ts": [
+			"eslint --report-unused-disable-directives --max-warnings 0",
+			"prettier --write"
+		],
+		"*.{mjs,cjs,json}": [
+			"prettier --write"
+		]
+	},
+	"devDependencies": {
+		"@types/node": "^22.19.7",
+		"@typescript-eslint/eslint-plugin": "^8.53.0",
+		"@typescript-eslint/parser": "^8.53.0",
+		"eslint": "^9.39.2",
+		"prettier": "^3.8.0",
+		"typescript": "^5.9.3"
+	}
+}

--- a/packages/cli/src/adapters/network.ts
+++ b/packages/cli/src/adapters/network.ts
@@ -1,0 +1,77 @@
+import { connect } from "node:net";
+
+export interface ProbeResult {
+	ok: boolean;
+	message: string;
+	statusCode?: number;
+}
+
+export async function probeHttp(url: string, timeoutMs = 2_000): Promise<ProbeResult> {
+	try {
+		const response = await fetch(url, {
+			method: "GET",
+			redirect: "manual",
+			signal: AbortSignal.timeout(timeoutMs),
+		});
+		return {
+			ok: response.status >= 200 && response.status < 400,
+			message: `HTTP ${response.status}`,
+			statusCode: response.status,
+		};
+	} catch (error) {
+		return {
+			ok: false,
+			message: error instanceof Error ? error.message : String(error),
+		};
+	}
+}
+
+export async function probeTcp(
+	host: string,
+	port: number,
+	timeoutMs = 2_000
+): Promise<ProbeResult> {
+	return await new Promise<ProbeResult>((resolve) => {
+		let settled = false;
+		const socket = connect({ host, port });
+		const finish = (result: ProbeResult): void => {
+			if (settled) return;
+			settled = true;
+			clearTimeout(timer);
+			socket.destroy();
+			resolve(result);
+		};
+		const timer = setTimeout(
+			() => finish({ ok: false, message: "connection timed out" }),
+			timeoutMs
+		);
+		timer.unref();
+		socket.once("connect", () => finish({ ok: true, message: "TCP connection succeeded" }));
+		socket.once("error", (error) => finish({ ok: false, message: error.message }));
+	});
+}
+
+export function parseHostPort(
+	value: string,
+	defaultPort: number
+): { host: string; port: number } | undefined {
+	try {
+		const url = new URL(value.includes("://") ? value : `http://${value}`);
+		const port = url.port ? Number(url.port) : defaultPort;
+		if (!url.hostname || !Number.isInteger(port) || port < 1 || port > 65_535) {
+			return undefined;
+		}
+		const host = url.hostname.replace(/^\[|\]$/g, "");
+		return { host, port };
+	} catch {
+		return undefined;
+	}
+}
+
+export function originFromCallback(value: string): string | undefined {
+	try {
+		return new URL(value).origin;
+	} catch {
+		return undefined;
+	}
+}

--- a/packages/cli/src/adapters/yorkie-cli.ts
+++ b/packages/cli/src/adapters/yorkie-cli.ts
@@ -1,0 +1,143 @@
+import { OperationalError } from "../core/errors.js";
+import { CommandRunner } from "../core/process.js";
+
+export const REQUIRED_EVENT = "DocumentRootChanged";
+
+export interface YorkieProject {
+	name: string;
+	secretKey?: string;
+	publicKey?: string;
+	eventWebhookUrl?: string;
+	eventWebhookEvents: string[];
+}
+
+function stringField(record: Record<string, unknown>, ...keys: string[]): string | undefined {
+	for (const key of keys) {
+		const value = record[key];
+		if (typeof value === "string") return value;
+	}
+	return undefined;
+}
+
+function stringListField(record: Record<string, unknown>, ...keys: string[]): string[] {
+	for (const key of keys) {
+		const value = record[key];
+		if (Array.isArray(value)) {
+			return value.filter((entry): entry is string => typeof entry === "string");
+		}
+		if (typeof value === "string") {
+			return value
+				.split(",")
+				.map((entry) => entry.trim())
+				.filter(Boolean);
+		}
+	}
+	return [];
+}
+
+function unwrapProjectRecords(value: unknown): Record<string, unknown>[] {
+	if (Array.isArray(value)) {
+		return value.filter(
+			(entry): entry is Record<string, unknown> =>
+				typeof entry === "object" && entry !== null && !Array.isArray(entry)
+		);
+	}
+	if (typeof value === "object" && value !== null && !Array.isArray(value)) {
+		const record = value as Record<string, unknown>;
+		for (const key of ["projects", "items", "data"]) {
+			if (Array.isArray(record[key])) return unwrapProjectRecords(record[key]);
+		}
+	}
+	throw new OperationalError(
+		"Yorkie project list returned an unexpected JSON shape.",
+		"INVALID_YORKIE_PROJECT_OUTPUT"
+	);
+}
+
+export function parseYorkieProjects(output: string): YorkieProject[] {
+	let parsed: unknown;
+	try {
+		parsed = JSON.parse(output.trim());
+	} catch (error) {
+		throw new OperationalError(
+			"Yorkie project list did not return valid JSON.",
+			"INVALID_YORKIE_PROJECT_JSON",
+			{ cause: error }
+		);
+	}
+
+	return unwrapProjectRecords(parsed).map((record) => {
+		const name = stringField(record, "name");
+		if (!name) {
+			throw new OperationalError(
+				"Yorkie project data is missing a project name.",
+				"INVALID_YORKIE_PROJECT_OUTPUT"
+			);
+		}
+		return {
+			name,
+			secretKey: stringField(record, "secret_key", "secretKey"),
+			publicKey: stringField(record, "public_key", "publicKey"),
+			eventWebhookUrl: stringField(record, "event_webhook_url", "eventWebhookUrl"),
+			eventWebhookEvents: stringListField(
+				record,
+				"event_webhook_events",
+				"eventWebhookEvents"
+			),
+		};
+	});
+}
+
+export class YorkieCli {
+	constructor(
+		private readonly runner: CommandRunner,
+		private readonly rpcAddress: string
+	) {}
+
+	async assertAvailable(): Promise<void> {
+		await this.runner.run("yorkie", ["--help"], { timeoutMs: 5_000 });
+	}
+
+	async login(username: string, password: string, insecure: boolean): Promise<void> {
+		this.runner.addSecret(password);
+		const args = ["login", "-u", username, "-p", password];
+		if (insecure) args.push("--insecure");
+		args.push("--rpc-addr", this.rpcAddress);
+		await this.runner.run("yorkie", args, { timeoutMs: 20_000 });
+	}
+
+	async listProjects(): Promise<YorkieProject[]> {
+		const result = await this.runner.run(
+			"yorkie",
+			["project", "ls", "--verbose", "--output", "json", "--rpc-addr", this.rpcAddress],
+			{ timeoutMs: 15_000 }
+		);
+		return parseYorkieProjects(result.stdout);
+	}
+
+	async createProject(name: string): Promise<void> {
+		await this.runner.run(
+			"yorkie",
+			["project", "create", name, "--rpc-addr", this.rpcAddress],
+			{ timeoutMs: 15_000 }
+		);
+	}
+
+	async configureEventWebhook(name: string, webhookUrl: string): Promise<void> {
+		await this.runner.run(
+			"yorkie",
+			[
+				"project",
+				"update",
+				name,
+				"--event-webhook-url",
+				webhookUrl,
+				"--event-webhook-events-add",
+				REQUIRED_EVENT,
+				"--rpc-addr",
+				this.rpcAddress,
+			],
+			{ timeoutMs: 15_000 }
+		);
+	}
+}

--- a/packages/cli/src/checks/context.ts
+++ b/packages/cli/src/checks/context.ts
@@ -1,0 +1,55 @@
+import { CommandRunner } from "../core/process.js";
+import { readEnv, type ParsedEnvFile } from "../core/env-file.js";
+import { resolveProjectPath } from "../core/project-root.js";
+
+export interface DoctorContext {
+	root: string;
+	runner: CommandRunner;
+	backendEnv: ParsedEnvFile;
+	frontendEnv: ParsedEnvFile;
+}
+
+export interface DoctorContextOptions {
+	backendEnvPath?: string;
+	frontendEnvPath?: string;
+}
+
+export async function createDoctorContext(
+	root: string,
+	options: DoctorContextOptions = {}
+): Promise<DoctorContext> {
+	const [backendEnv, frontendEnv] = await Promise.all([
+		readEnv(
+			resolveProjectPath(root, options.backendEnvPath, [
+				"packages",
+				"backend",
+				".env.development",
+			])
+		),
+		readEnv(
+			resolveProjectPath(root, options.frontendEnvPath, [
+				"packages",
+				"frontend",
+				".env.development",
+			])
+		),
+	]);
+	return {
+		root,
+		runner: new CommandRunner(),
+		backendEnv,
+		frontendEnv,
+	};
+}
+
+export function envValue(
+	context: DoctorContext,
+	key: string,
+	preference: "backend" | "frontend" = "backend"
+): string | undefined {
+	const processValue = process.env[key]?.trim();
+	if (processValue) return processValue;
+	return preference === "backend"
+		? context.backendEnv.values.get(key)
+		: context.frontendEnv.values.get(key);
+}

--- a/packages/cli/src/checks/env.ts
+++ b/packages/cli/src/checks/env.ts
@@ -1,0 +1,157 @@
+import type { DoctorCheck } from "../types.js";
+import type { DoctorContext } from "./context.js";
+
+const REQUIRED_BACKEND = [
+	"DATABASE_URL",
+	"GITHUB_CLIENT_ID",
+	"GITHUB_CLIENT_SECRET",
+	"GITHUB_CALLBACK_URL",
+	"JWT_ACCESS_TOKEN_SECRET",
+	"JWT_ACCESS_TOKEN_EXPIRATION_TIME",
+	"JWT_REFRESH_TOKEN_SECRET",
+	"JWT_REFRESH_TOKEN_EXPIRATION_TIME",
+	"FRONTEND_BASE_URL",
+	"YORKIE_API_ADDR",
+	"YORKIE_PROJECT_SECRET_KEY",
+] as const;
+
+const REQUIRED_FRONTEND = ["VITE_API_ADDR", "VITE_YORKIE_API_ADDR", "VITE_YORKIE_API_KEY"] as const;
+
+const UNSAFE_SECRET_VALUES = new Set([
+	"admin",
+	"password",
+	"secret",
+	"you_should_change_this_access_token_secret_key_in_production",
+	"you_should_change_this_refresh_token_secret_key_in_production",
+	"your_yorkie_project_secret_key_here",
+]);
+
+function fileCheck(id: string, label: string, file: DoctorContext["backendEnv"]): DoctorCheck {
+	return file.exists
+		? {
+				id,
+				scope: "env",
+				status: "pass",
+				message: `${label} exists.`,
+				details: { path: file.path },
+			}
+		: {
+				id,
+				scope: "env",
+				status: "fail",
+				message: `${label} is missing.`,
+				details: { path: file.path },
+				remediation: "Create the development environment file before starting CodePair.",
+			};
+}
+
+function requiredKeysCheck(
+	id: string,
+	label: string,
+	values: Map<string, string>,
+	required: readonly string[]
+): DoctorCheck {
+	const missing = required.filter((key) => !values.get(key)?.trim());
+	return missing.length === 0
+		? {
+				id,
+				scope: "env",
+				status: "pass",
+				message: `${label} contains all required variables.`,
+			}
+		: {
+				id,
+				scope: "env",
+				status: "fail",
+				message: `${label} is missing ${missing.length} required variable(s).`,
+				details: { missing },
+				remediation: `Define: ${missing.join(", ")}`,
+			};
+}
+
+function secretSafetyCheck(context: DoctorContext): DoctorCheck {
+	const secretKeys = [
+		"GITHUB_CLIENT_SECRET",
+		"JWT_ACCESS_TOKEN_SECRET",
+		"JWT_REFRESH_TOKEN_SECRET",
+		"YORKIE_PROJECT_SECRET_KEY",
+	] as const;
+	const unsafe = secretKeys.filter((key) => {
+		const value = context.backendEnv.values.get(key)?.trim().toLowerCase();
+		return value !== undefined && UNSAFE_SECRET_VALUES.has(value);
+	});
+	return unsafe.length === 0
+		? {
+				id: "env.secrets",
+				scope: "env",
+				status: "pass",
+				message: "Configured backend secrets do not use known placeholder values.",
+			}
+		: {
+				id: "env.secrets",
+				scope: "env",
+				status: "warn",
+				message: `${unsafe.length} backend secret(s) use a default or placeholder value.`,
+				details: { variables: unsafe },
+				remediation:
+					"Replace placeholder credentials before exposing CodePair beyond localhost.",
+			};
+}
+
+function urlConsistencyCheck(context: DoctorContext): DoctorCheck {
+	const callback = context.backendEnv.values.get("GITHUB_CALLBACK_URL");
+	const frontend = context.backendEnv.values.get("FRONTEND_BASE_URL");
+	const invalid: string[] = [];
+	for (const [key, value] of [
+		["GITHUB_CALLBACK_URL", callback],
+		["FRONTEND_BASE_URL", frontend],
+	] as const) {
+		if (!value) continue;
+		try {
+			const parsed = new URL(value);
+			if (parsed.protocol !== "http:" && parsed.protocol !== "https:") invalid.push(key);
+		} catch {
+			invalid.push(key);
+		}
+	}
+	if (callback && !callback.endsWith("/auth/login/github"))
+		invalid.push("GITHUB_CALLBACK_URL path");
+
+	return invalid.length === 0
+		? {
+				id: "env.urls",
+				scope: "env",
+				status: "pass",
+				message: "Configured application URLs are syntactically consistent.",
+			}
+		: {
+				id: "env.urls",
+				scope: "env",
+				status: "fail",
+				message: "One or more application URLs are invalid.",
+				details: { invalid },
+				remediation:
+					"Use absolute http(s) URLs and end GITHUB_CALLBACK_URL with /auth/login/github.",
+			};
+}
+
+export function runEnvChecks(context: DoctorContext): DoctorCheck[] {
+	return [
+		fileCheck("env.backend.file", "Backend .env.development", context.backendEnv),
+		requiredKeysCheck(
+			"env.backend.required",
+			"Backend .env.development",
+			context.backendEnv.values,
+			REQUIRED_BACKEND
+		),
+		fileCheck("env.frontend.file", "Frontend .env.development", context.frontendEnv),
+		requiredKeysCheck(
+			"env.frontend.required",
+			"Frontend .env.development",
+			context.frontendEnv.values,
+			REQUIRED_FRONTEND
+		),
+		secretSafetyCheck(context),
+		urlConsistencyCheck(context),
+	];
+}

--- a/packages/cli/src/checks/services.ts
+++ b/packages/cli/src/checks/services.ts
@@ -1,0 +1,116 @@
+import { probeHttp, probeTcp, parseHostPort, originFromCallback } from "../adapters/network.js";
+import type { DoctorCheck } from "../types.js";
+import { envValue, type DoctorContext } from "./context.js";
+
+function skipped(id: string, message: string): DoctorCheck {
+	return { id, scope: "services", status: "skip", message };
+}
+
+export async function httpCheck(
+	id: string,
+	label: string,
+	url: string | undefined,
+	path: string
+): Promise<DoctorCheck> {
+	if (!url) return skipped(id, `${label} endpoint is not configured.`);
+	let target: string;
+	try {
+		const base = new URL(url);
+		if (base.username || base.password) {
+			return {
+				id,
+				scope: "services",
+				status: "fail",
+				message: `${label} endpoint must not contain URL credentials.`,
+				remediation: `Remove the username and password from the configured ${label} URL.`,
+			};
+		}
+		target = new URL(path, base).toString();
+	} catch {
+		return {
+			id,
+			scope: "services",
+			status: "fail",
+			message: `${label} endpoint is invalid.`,
+			remediation: `Correct the configured ${label} URL.`,
+		};
+	}
+	const result = await probeHttp(target);
+	return result.ok
+		? {
+				id,
+				scope: "services",
+				status: "pass",
+				message: `${label} is reachable (${result.message}).`,
+				details: { endpoint: target },
+			}
+		: {
+				id,
+				scope: "services",
+				status: "fail",
+				message: `${label} is not reachable.`,
+				details: { endpoint: target, diagnostic: result.message },
+				remediation: `Start ${label} and verify its configured address.`,
+			};
+}
+
+async function tcpCheck(
+	id: string,
+	label: string,
+	address: string | undefined,
+	defaultPort: number
+): Promise<DoctorCheck> {
+	if (!address) return skipped(id, `${label} address is not configured.`);
+	const endpoint = parseHostPort(address, defaultPort);
+	if (!endpoint) {
+		return {
+			id,
+			scope: "services",
+			status: "fail",
+			message: `${label} address is invalid.`,
+			remediation: `Correct the configured ${label} address.`,
+		};
+	}
+	const result = await probeTcp(endpoint.host, endpoint.port);
+	return result.ok
+		? {
+				id,
+				scope: "services",
+				status: "pass",
+				message: `${label} accepts TCP connections.`,
+				details: endpoint,
+			}
+		: {
+				id,
+				scope: "services",
+				status: "fail",
+				message: `${label} is not reachable.`,
+				details: { ...endpoint, diagnostic: result.message },
+				remediation: `Start ${label} and verify networking from this host.`,
+			};
+}
+
+export async function runServiceChecks(context: DoctorContext): Promise<DoctorCheck[]> {
+	const callbackOrigin = originFromCallback(envValue(context, "GITHUB_CALLBACK_URL") ?? "");
+	const backendBase =
+		envValue(context, "VITE_API_ADDR", "frontend") ?? callbackOrigin ?? "http://localhost:3000";
+	const yorkieAddress =
+		envValue(context, "VITE_YORKIE_API_ADDR", "frontend") ??
+		envValue(context, "YORKIE_API_ADDR") ??
+		process.env.YORKIE_API_ADDR ??
+		"localhost:8080";
+
+	return await Promise.all([
+		httpCheck("services.backend", "CodePair backend", backendBase, "/settings"),
+		tcpCheck("services.yorkie", "Yorkie", yorkieAddress, 8080),
+		tcpCheck("services.mongo", "MongoDB", envValue(context, "DATABASE_URL"), 27017),
+		httpCheck("services.qdrant", "Qdrant", envValue(context, "QDRANT_URL"), "/healthz"),
+		httpCheck("services.ollama", "Ollama", envValue(context, "OLLAMA_HOST_URL"), "/api/tags"),
+		httpCheck(
+			"services.minio",
+			"MinIO",
+			envValue(context, "MINIO_ENDPOINT"),
+			"/minio/health/live"
+		),
+	]);
+}

--- a/packages/cli/src/checks/toolchain.ts
+++ b/packages/cli/src/checks/toolchain.ts
@@ -1,0 +1,124 @@
+import type { DoctorCheck } from "../types.js";
+import type { DoctorContext } from "./context.js";
+
+interface ToolProbe {
+	id: string;
+	command: string;
+	args: string[];
+	remediationCommand?: string;
+	required: boolean;
+	label: string;
+	expectedMajor?: number;
+}
+
+function nodeCheck(): DoctorCheck {
+	const major = Number(process.versions.node.split(".")[0]);
+	if (major === 20 || major === 22 || major === 24) {
+		return {
+			id: "toolchain.node",
+			scope: "toolchain",
+			status: "pass",
+			message: `Node.js ${process.versions.node} is supported.`,
+		};
+	}
+	return {
+		id: "toolchain.node",
+		scope: "toolchain",
+		status: "fail",
+		message: `Node.js ${process.versions.node} is not supported.`,
+		remediation: "Install a supported LTS release: Node.js 20, 22, or 24.",
+	};
+}
+
+function firstVersionMajor(output: string): number | undefined {
+	const match = /(?:^|\s|v)(\d+)\.\d+(?:\.\d+)?(?:\s|$)/.exec(output.trim());
+	if (!match?.[1]) return undefined;
+	const major = Number(match[1]);
+	return Number.isInteger(major) ? major : undefined;
+}
+
+async function probeTool(context: DoctorContext, probe: ToolProbe): Promise<DoctorCheck> {
+	const remediationCommand = probe.remediationCommand ?? probe.command;
+	try {
+		const result = await context.runner.run(probe.command, probe.args, {
+			allowFailure: true,
+			timeoutMs: 5_000,
+		});
+		if (result.exitCode === 0) {
+			const version = (result.stdout || result.stderr).trim().split(/\r?\n/)[0];
+			if (probe.expectedMajor !== undefined) {
+				const major = firstVersionMajor(version ?? "");
+				if (major !== probe.expectedMajor) {
+					return {
+						id: probe.id,
+						scope: "toolchain",
+						status: "fail",
+						message: `${probe.label} ${version || "with an unknown version"} is not supported.`,
+						remediation: `Install ${probe.label} ${probe.expectedMajor}.x.`,
+					};
+				}
+			}
+			return {
+				id: probe.id,
+				scope: "toolchain",
+				status: "pass",
+				message: `${probe.label} is available${version ? ` (${version})` : ""}.`,
+			};
+		}
+		return {
+			id: probe.id,
+			scope: "toolchain",
+			status: probe.required ? "fail" : "warn",
+			message: `${probe.label} returned exit code ${result.exitCode}.`,
+			remediation: `Verify that ${remediationCommand} is installed and usable from this shell.`,
+		};
+	} catch {
+		return {
+			id: probe.id,
+			scope: "toolchain",
+			status: probe.required ? "fail" : "warn",
+			message: `${probe.label} is not available.`,
+			remediation: `Install ${probe.label} and ensure ${remediationCommand} is on PATH.`,
+		};
+	}
+}
+
+export async function runToolchainChecks(context: DoctorContext): Promise<DoctorCheck[]> {
+	const probes: ToolProbe[] = [
+		{
+			id: "toolchain.pnpm",
+			command: process.platform === "win32" ? (process.env.ComSpec ?? "cmd.exe") : "pnpm",
+			args:
+				process.platform === "win32" ? ["/d", "/s", "/c", "pnpm --version"] : ["--version"],
+			remediationCommand: "pnpm",
+			required: true,
+			label: "pnpm",
+			expectedMajor: 9,
+		},
+		{
+			id: "toolchain.yorkie",
+			command: "yorkie",
+			args: ["--help"],
+			required: true,
+			label: "Yorkie CLI",
+		},
+		{
+			id: "toolchain.docker",
+			command: "docker",
+			args: ["--version"],
+			required: true,
+			label: "Docker",
+		},
+		{
+			id: "toolchain.compose",
+			command: "docker",
+			args: ["compose", "version"],
+			required: true,
+			label: "Docker Compose",
+		},
+	];
+	return [
+		nodeCheck(),
+		...(await Promise.all(probes.map(async (probe) => await probeTool(context, probe)))),
+	];
+}

--- a/packages/cli/src/checks/yorkie.ts
+++ b/packages/cli/src/checks/yorkie.ts
@@ -1,0 +1,212 @@
+import { REQUIRED_EVENT, YorkieCli } from "../adapters/yorkie-cli.js";
+import {
+	normalizeYorkieRpcEndpoint,
+	validateWebhookUrl,
+	type YorkieRpcEndpoint,
+} from "../core/url.js";
+import type { DoctorCheck } from "../types.js";
+import type { DoctorContext } from "./context.js";
+
+export interface YorkieCheckOptions {
+	rpcAddress: string;
+	projectName: string;
+	webhookUrl: string;
+}
+
+function configurationFailure(message: string, remediation: string): DoctorCheck {
+	return {
+		id: "yorkie.configuration",
+		scope: "yorkie",
+		status: "fail",
+		message,
+		remediation,
+	};
+}
+
+function localAddressProblem(context: DoctorContext): DoctorCheck | undefined {
+	const configured = [
+		["YORKIE_API_ADDR", context.backendEnv.values.get("YORKIE_API_ADDR")?.trim()],
+		["VITE_YORKIE_API_ADDR", context.frontendEnv.values.get("VITE_YORKIE_API_ADDR")?.trim()],
+	] as const;
+	const endpoints: Array<readonly [string, YorkieRpcEndpoint]> = [];
+	for (const [name, value] of configured) {
+		if (!value) continue;
+		try {
+			endpoints.push([name, normalizeYorkieRpcEndpoint(value)] as const);
+		} catch {
+			return configurationFailure(
+				`${name} is not a valid Yorkie address.`,
+				`Correct ${name}, then rerun codepair doctor.`
+			);
+		}
+	}
+	if (endpoints.length === 2 && endpoints[0]?.[1].httpUrl !== endpoints[1]?.[1].httpUrl) {
+		return configurationFailure(
+			"Backend and frontend Yorkie addresses do not match.",
+			"Run codepair setup yorkie with an explicit --rpc-addr to synchronize both files."
+		);
+	}
+	return undefined;
+}
+
+function localProjectKeyCheck(
+	id: string,
+	label: string,
+	configured: string | undefined,
+	projectValue: string | undefined
+): DoctorCheck {
+	if (!projectValue) {
+		return {
+			id,
+			scope: "yorkie",
+			status: "skip",
+			message: `${label} cannot be compared because the project key is unavailable.`,
+		};
+	}
+	if (!configured) {
+		return {
+			id,
+			scope: "yorkie",
+			status: "fail",
+			message: `${label} is not configured.`,
+			remediation: "Run codepair setup yorkie to synchronize local project keys.",
+		};
+	}
+	if (configured === projectValue) {
+		return {
+			id,
+			scope: "yorkie",
+			status: "pass",
+			message: `${label} matches the selected Yorkie project.`,
+		};
+	}
+	return {
+		id,
+		scope: "yorkie",
+		status: "fail",
+		message: `${label} does not match the selected Yorkie project.`,
+		remediation: "Run codepair setup yorkie to synchronize local project keys.",
+	};
+}
+
+export async function runYorkieChecks(
+	context: DoctorContext,
+	options: YorkieCheckOptions
+): Promise<DoctorCheck[]> {
+	const localProblem = localAddressProblem(context);
+	if (localProblem) return [localProblem];
+
+	let endpoint: YorkieRpcEndpoint;
+	try {
+		endpoint = normalizeYorkieRpcEndpoint(options.rpcAddress);
+		validateWebhookUrl(options.webhookUrl);
+	} catch {
+		return [
+			configurationFailure(
+				"The selected Yorkie address or webhook URL is invalid.",
+				"Correct the environment value or pass a valid doctor option."
+			),
+		];
+	}
+	const cli = new YorkieCli(context.runner, endpoint.rpcAddress);
+
+	try {
+		await cli.assertAvailable();
+	} catch {
+		return [
+			{
+				id: "yorkie.cli",
+				scope: "yorkie",
+				status: "fail",
+				message: "Yorkie CLI is not available.",
+				remediation: "Install Yorkie CLI and ensure yorkie is on PATH.",
+			},
+		];
+	}
+
+	let projects;
+	try {
+		projects = await cli.listProjects();
+	} catch {
+		return [
+			{
+				id: "yorkie.connection",
+				scope: "yorkie",
+				status: "fail",
+				message: `Could not list Yorkie projects at ${endpoint.rpcAddress}.`,
+				remediation: "Run codepair setup yorkie or log in with Yorkie CLI.",
+			},
+		];
+	}
+
+	const project = projects.find((candidate) => candidate.name === options.projectName);
+	if (!project) {
+		return [
+			{
+				id: "yorkie.project",
+				scope: "yorkie",
+				status: "fail",
+				message: `Yorkie project ${options.projectName} does not exist.`,
+				remediation: "Run codepair setup yorkie to create and configure it.",
+			},
+		];
+	}
+
+	const keysPresent = Boolean(project.secretKey && project.publicKey);
+	const backendSecret = context.backendEnv.values.get("YORKIE_PROJECT_SECRET_KEY");
+	const frontendPublicKey = context.frontendEnv.values.get("VITE_YORKIE_API_KEY");
+	const webhookMatches = project.eventWebhookUrl === options.webhookUrl;
+	const eventPresent = project.eventWebhookEvents.includes(REQUIRED_EVENT);
+	return [
+		{
+			id: "yorkie.project",
+			scope: "yorkie",
+			status: "pass",
+			message: `Yorkie project ${options.projectName} exists.`,
+		},
+		keysPresent
+			? {
+					id: "yorkie.keys",
+					scope: "yorkie",
+					status: "pass",
+					message: "Yorkie project public and secret keys are available.",
+				}
+			: {
+					id: "yorkie.keys",
+					scope: "yorkie",
+					status: "fail",
+					message: "Yorkie project data is missing a public or secret key.",
+					remediation: "Verify Yorkie CLI/server compatibility and project permissions.",
+				},
+		localProjectKeyCheck(
+			"yorkie.backend-key",
+			"Backend Yorkie project secret",
+			backendSecret,
+			project.secretKey
+		),
+		localProjectKeyCheck(
+			"yorkie.frontend-key",
+			"Frontend Yorkie API key",
+			frontendPublicKey,
+			project.publicKey
+		),
+		webhookMatches && eventPresent
+			? {
+					id: "yorkie.webhook",
+					scope: "yorkie",
+					status: "pass",
+					message: "Yorkie DocumentRootChanged event webhook is configured.",
+				}
+			: {
+					id: "yorkie.webhook",
+					scope: "yorkie",
+					status: "fail",
+					message: "Yorkie event webhook does not match the expected URL and event.",
+					details: {
+						urlMatches: webhookMatches,
+						documentRootChangedEnabled: eventPresent,
+					},
+					remediation: "Run codepair setup yorkie with the intended --webhook-url.",
+				},
+	];
+}

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -1,0 +1,5 @@
+#!/usr/bin/env node
+
+import { runCli } from "./main.js";
+
+process.exitCode = await runCli(process.argv.slice(2));

--- a/packages/cli/src/commands/doctor.ts
+++ b/packages/cli/src/commands/doctor.ts
@@ -1,0 +1,166 @@
+import { runEnvChecks } from "../checks/env.js";
+import { createDoctorContext, envValue, type DoctorContext } from "../checks/context.js";
+import { runServiceChecks } from "../checks/services.js";
+import { runToolchainChecks } from "../checks/toolchain.js";
+import { runYorkieChecks, type YorkieCheckOptions } from "../checks/yorkie.js";
+import { optionValue } from "../core/args.js";
+import { UsageError } from "../core/errors.js";
+import { discoverProjectRoot } from "../core/project-root.js";
+import { normalizeYorkieRpcEndpoint, validateWebhookUrl } from "../core/url.js";
+import {
+	EXIT_FAILURE,
+	EXIT_SUCCESS,
+	type CheckScope,
+	type DoctorCheck,
+	type DoctorResult,
+	type DoctorSummary,
+	type RequestedScope,
+} from "../types.js";
+
+export interface DoctorOptions {
+	root?: string;
+	strict: boolean;
+	scope: RequestedScope;
+	rpcAddress?: string;
+	projectName?: string;
+	webhookUrl?: string;
+	backendEnvPath?: string;
+	frontendEnvPath?: string;
+}
+
+const SCOPES = new Set<RequestedScope>(["all", "toolchain", "env", "services", "yorkie"]);
+const DEFAULT_RPC_ADDRESS = "localhost:8080";
+const DEFAULT_PROJECT_NAME = "codepair";
+const DEFAULT_WEBHOOK_URL = "http://host.docker.internal:3000/yorkie/document-events";
+const STRING_OPTIONS = [
+	["--rpc-addr", "rpcAddress"],
+	["--project", "projectName"],
+	["--webhook-url", "webhookUrl"],
+	["--backend-env", "backendEnvPath"],
+	["--frontend-env", "frontendEnvPath"],
+] as const satisfies ReadonlyArray<readonly [string, keyof DoctorOptions]>;
+
+function environment(name: string): string | undefined {
+	return process.env[name]?.trim() || undefined;
+}
+
+function selectedYorkieConfiguration(
+	context: DoctorContext,
+	options: DoctorOptions
+): YorkieCheckOptions {
+	return {
+		rpcAddress:
+			options.rpcAddress ??
+			envValue(context, "YORKIE_API_ADDR") ??
+			envValue(context, "VITE_YORKIE_API_ADDR", "frontend") ??
+			DEFAULT_RPC_ADDRESS,
+		projectName:
+			options.projectName ?? envValue(context, "YORKIE_PROJECT_NAME") ?? DEFAULT_PROJECT_NAME,
+		webhookUrl: options.webhookUrl ?? envValue(context, "WEBHOOK_URL") ?? DEFAULT_WEBHOOK_URL,
+	};
+}
+
+export function parseDoctorOptions(tokens: readonly string[], root?: string): DoctorOptions {
+	const options: DoctorOptions = {
+		root,
+		strict: false,
+		scope: "all",
+	};
+	const rpcAddress = environment("YORKIE_API_ADDR");
+	const projectName = environment("YORKIE_PROJECT_NAME");
+	const webhookUrl = environment("WEBHOOK_URL");
+	const backendEnvPath = environment("BACKEND_ENV_FILE");
+	const frontendEnvPath = environment("FRONTEND_ENV_FILE");
+	if (rpcAddress) options.rpcAddress = rpcAddress;
+	if (projectName) options.projectName = projectName;
+	if (webhookUrl) options.webhookUrl = webhookUrl;
+	if (backendEnvPath) options.backendEnvPath = backendEnvPath;
+	if (frontendEnvPath) options.frontendEnvPath = frontendEnvPath;
+
+	for (let index = 0; index < tokens.length; ) {
+		const token = tokens[index];
+		let matched = false;
+		for (const [name, key] of STRING_OPTIONS) {
+			const parsed = optionValue(tokens, index, name);
+			if (!parsed) continue;
+			if (name === "--rpc-addr") normalizeYorkieRpcEndpoint(parsed.value);
+			if (name === "--webhook-url") validateWebhookUrl(parsed.value);
+			options[key] = parsed.value;
+			index += parsed.consumed;
+			matched = true;
+			break;
+		}
+		if (matched) continue;
+
+		const parsedScope = optionValue(tokens, index, "--scope");
+		if (parsedScope) {
+			if (!SCOPES.has(parsedScope.value as RequestedScope)) {
+				throw new UsageError(
+					`Invalid doctor scope: ${parsedScope.value}. Expected all, toolchain, env, services, or yorkie.`,
+					"INVALID_SCOPE"
+				);
+			}
+			options.scope = parsedScope.value as RequestedScope;
+			index += parsedScope.consumed;
+			continue;
+		}
+
+		if (token === "--strict") {
+			options.strict = true;
+			index += 1;
+			continue;
+		}
+		throw new UsageError(`Unknown doctor option: ${token ?? ""}`, "UNKNOWN_OPTION");
+	}
+
+	if (options.projectName !== undefined && !options.projectName.trim()) {
+		throw new UsageError("--project must not be empty.");
+	}
+	return options;
+}
+
+function summarize(checks: readonly DoctorCheck[]): DoctorSummary {
+	const summary: DoctorSummary = { pass: 0, warn: 0, fail: 0, skip: 0 };
+	for (const check of checks) summary[check.status] += 1;
+	return summary;
+}
+
+function selected(requested: RequestedScope, scope: CheckScope): boolean {
+	return requested === "all" || requested === scope;
+}
+
+export async function runDoctor(options: DoctorOptions): Promise<DoctorResult> {
+	const root = await discoverProjectRoot(options.root);
+	const context = await createDoctorContext(root, {
+		backendEnvPath: options.backendEnvPath,
+		frontendEnvPath: options.frontendEnvPath,
+	});
+	const checks: DoctorCheck[] = [];
+
+	if (selected(options.scope, "toolchain")) {
+		checks.push(...(await runToolchainChecks(context)));
+	}
+	if (selected(options.scope, "env")) {
+		checks.push(...runEnvChecks(context));
+	}
+	if (selected(options.scope, "services")) {
+		checks.push(...(await runServiceChecks(context)));
+	}
+	if (selected(options.scope, "yorkie")) {
+		checks.push(
+			...(await runYorkieChecks(context, selectedYorkieConfiguration(context, options)))
+		);
+	}
+
+	const summary = summarize(checks);
+	const ok = summary.fail === 0 && (!options.strict || summary.warn === 0);
+	return {
+		command: "doctor",
+		ok,
+		exitCode: ok ? EXIT_SUCCESS : EXIT_FAILURE,
+		root,
+		strict: options.strict,
+		checks,
+		summary,
+	};
+}

--- a/packages/cli/src/commands/setup-yorkie.ts
+++ b/packages/cli/src/commands/setup-yorkie.ts
@@ -1,0 +1,451 @@
+import { access, readFile } from "node:fs/promises";
+import { constants } from "node:fs";
+import { resolve } from "node:path";
+import { REQUIRED_EVENT, YorkieCli, type YorkieProject } from "../adapters/yorkie-cli.js";
+import { UsageError, OperationalError } from "../core/errors.js";
+import { parseEnv, readEnv, updateEnvFileAtomic } from "../core/env-file.js";
+import { optionValue } from "../core/args.js";
+import { CommandRunner } from "../core/process.js";
+import { discoverProjectRoot, resolveProjectPath } from "../core/project-root.js";
+import { confirmMutation, readPasswordFromStdin } from "../core/prompt.js";
+import {
+	assertSafeTransport,
+	normalizeYorkieRpcEndpoint,
+	validateWebhookUrl,
+	type YorkieRpcEndpoint,
+	type YorkieTransport,
+} from "../core/url.js";
+import { EXIT_SUCCESS, type SetupAction, type SetupResult } from "../types.js";
+
+export interface SetupYorkieOptions {
+	root?: string;
+	rpcAddress?: string;
+	projectName: string;
+	username: string;
+	passwordFromStdin: boolean;
+	webhookUrl: string;
+	backendEnvPath?: string;
+	frontendEnvPath?: string;
+	secure?: boolean;
+	allowInsecureRemote: boolean;
+	legacyEnvironmentKeysOnly: boolean;
+	yes: boolean;
+	dryRun: boolean;
+}
+
+function environment(name: string, fallback: string): string {
+	return process.env[name]?.trim() || fallback;
+}
+
+function optionalEnvironment(name: string): string | undefined {
+	return process.env[name]?.trim() || undefined;
+}
+
+export function parseSetupYorkieOptions(
+	tokens: readonly string[],
+	root?: string
+): SetupYorkieOptions {
+	let transportMode: YorkieTransport | undefined;
+	const options: SetupYorkieOptions = {
+		root,
+		rpcAddress: optionalEnvironment("YORKIE_API_ADDR"),
+		projectName: environment("YORKIE_PROJECT_NAME", "codepair"),
+		username: environment("YORKIE_USERNAME", "admin"),
+		passwordFromStdin: false,
+		webhookUrl: environment(
+			"WEBHOOK_URL",
+			"http://host.docker.internal:3000/yorkie/document-events"
+		),
+		backendEnvPath: process.env.BACKEND_ENV_FILE,
+		frontendEnvPath: process.env.FRONTEND_ENV_FILE,
+		allowInsecureRemote: false,
+		legacyEnvironmentKeysOnly: process.env.CODEPAIR_LEGACY_SETUP === "1",
+		yes: false,
+		dryRun: false,
+	};
+
+	for (let index = 0; index < tokens.length; ) {
+		const token = tokens[index];
+		const stringOptions: Array<[keyof SetupYorkieOptions, string]> = [
+			["rpcAddress", "--rpc-addr"],
+			["projectName", "--project"],
+			["username", "--username"],
+			["webhookUrl", "--webhook-url"],
+			["backendEnvPath", "--backend-env"],
+			["frontendEnvPath", "--frontend-env"],
+		];
+		let matched = false;
+		for (const [key, name] of stringOptions) {
+			const parsed = optionValue(tokens, index, name);
+			if (!parsed) continue;
+			(options as unknown as Record<string, unknown>)[key] = parsed.value;
+			index += parsed.consumed;
+			matched = true;
+			break;
+		}
+		if (matched) continue;
+
+		switch (token) {
+			case "--password-stdin":
+				options.passwordFromStdin = true;
+				break;
+			case "--secure":
+				if (transportMode === "insecure") {
+					throw new UsageError(
+						"--secure and --insecure cannot be used together.",
+						"CONFLICTING_TRANSPORT_OPTIONS"
+					);
+				}
+				transportMode = "secure";
+				options.secure = true;
+				break;
+			case "--insecure":
+				if (transportMode === "secure") {
+					throw new UsageError(
+						"--secure and --insecure cannot be used together.",
+						"CONFLICTING_TRANSPORT_OPTIONS"
+					);
+				}
+				transportMode = "insecure";
+				options.secure = false;
+				break;
+			case "--allow-insecure-remote":
+				options.allowInsecureRemote = true;
+				break;
+			case "--yes":
+			case "-y":
+				options.yes = true;
+				break;
+			case "--dry-run":
+				options.dryRun = true;
+				break;
+			default:
+				throw new UsageError(`Unknown setup yorkie option: ${token}`, "UNKNOWN_OPTION");
+		}
+		index += 1;
+	}
+
+	if (!options.projectName.trim()) throw new UsageError("--project must not be empty.");
+	if (!options.username.trim()) throw new UsageError("--username must not be empty.");
+	if (options.rpcAddress !== undefined) {
+		const endpoint = normalizeYorkieRpcEndpoint(options.rpcAddress, transportMode);
+		options.rpcAddress = endpoint.rpcAddress;
+		options.secure = endpoint.secure;
+	}
+	return options;
+}
+
+async function exists(path: string): Promise<boolean> {
+	try {
+		await access(path, constants.F_OK);
+		return true;
+	} catch {
+		return false;
+	}
+}
+
+async function templateContent(
+	root: string,
+	target: string,
+	area: "backend" | "frontend"
+): Promise<string> {
+	if (await exists(target)) return "";
+	const template = resolve(root, "packages", area, ".env.example");
+	try {
+		return await readFile(template, "utf8");
+	} catch (error) {
+		if ((error as NodeJS.ErrnoException).code === "ENOENT") return "";
+		throw error;
+	}
+}
+
+interface EnvironmentSeed {
+	backendInitialContent: string;
+	frontendInitialContent: string;
+}
+
+function selectedSeedRpcAddress(seed: EnvironmentSeed): string | undefined {
+	const backendAddress = parseEnv(seed.backendInitialContent).get("YORKIE_API_ADDR")?.trim();
+	const frontendAddress = parseEnv(seed.frontendInitialContent)
+		.get("VITE_YORKIE_API_ADDR")
+		?.trim();
+	if (backendAddress && frontendAddress) {
+		const backendEndpoint = normalizeYorkieRpcEndpoint(backendAddress);
+		const frontendEndpoint = normalizeYorkieRpcEndpoint(frontendAddress);
+		if (backendEndpoint.httpUrl !== frontendEndpoint.httpUrl) {
+			throw new UsageError(
+				"Backend and frontend Yorkie addresses differ. Pass --rpc-addr to select one explicitly.",
+				"CONFLICTING_YORKIE_ADDRESSES"
+			);
+		}
+	}
+	return backendAddress || frontendAddress;
+}
+
+async function prepareEnvironmentSeed(
+	root: string,
+	backendEnvPath: string,
+	frontendEnvPath: string,
+	seedExamples: boolean
+): Promise<EnvironmentSeed> {
+	const backendFile = await readEnv(backendEnvPath);
+	const frontendFile = await readEnv(frontendEnvPath);
+	const backendInitialContent = backendFile.exists
+		? backendFile.content
+		: seedExamples
+			? await templateContent(root, backendEnvPath, "backend")
+			: "";
+	const frontendInitialContent = frontendFile.exists
+		? frontendFile.content
+		: seedExamples
+			? await templateContent(root, frontendEnvPath, "frontend")
+			: "";
+
+	return {
+		backendInitialContent,
+		frontendInitialContent,
+	};
+}
+
+function findProject(projects: readonly YorkieProject[], name: string): YorkieProject | undefined {
+	return projects.find((project) => project.name === name);
+}
+
+function assertProjectPostconditions(
+	project: YorkieProject | undefined,
+	projectName: string,
+	webhookUrl: string
+): asserts project is YorkieProject & { secretKey: string; publicKey: string } {
+	if (!project) {
+		throw new OperationalError(
+			`Yorkie project ${projectName} was not found after setup.`,
+			"PROJECT_VERIFICATION_FAILED"
+		);
+	}
+	if (!project.secretKey || !project.publicKey) {
+		throw new OperationalError(
+			"Yorkie project is missing its public or secret key after setup.",
+			"PROJECT_KEYS_MISSING"
+		);
+	}
+	if (project.eventWebhookUrl !== webhookUrl) {
+		throw new OperationalError(
+			"Yorkie event webhook URL did not match after setup.",
+			"WEBHOOK_VERIFICATION_FAILED"
+		);
+	}
+	if (!project.eventWebhookEvents.includes(REQUIRED_EVENT)) {
+		throw new OperationalError(
+			`${REQUIRED_EVENT} was not enabled after setup.`,
+			"WEBHOOK_EVENT_VERIFICATION_FAILED"
+		);
+	}
+}
+
+async function verifyEnvValue(path: string, key: string, expected: string): Promise<void> {
+	const file = await readEnv(path);
+	if (file.values.get(key) !== expected) {
+		throw new OperationalError(
+			`Failed to verify ${key} in ${path}.`,
+			"ENV_VERIFICATION_FAILED"
+		);
+	}
+}
+
+export async function runSetupYorkie(
+	options: SetupYorkieOptions,
+	runtime: { disablePrompt?: boolean } = {}
+): Promise<SetupResult> {
+	const root = await discoverProjectRoot(options.root);
+	const backendEnvPath = resolveProjectPath(root, options.backendEnvPath, [
+		"packages",
+		"backend",
+		".env.development",
+	]);
+	const frontendEnvPath = resolveProjectPath(root, options.frontendEnvPath, [
+		"packages",
+		"frontend",
+		".env.development",
+	]);
+	validateWebhookUrl(options.webhookUrl);
+	const seed = await prepareEnvironmentSeed(
+		root,
+		backendEnvPath,
+		frontendEnvPath,
+		!options.legacyEnvironmentKeysOnly
+	);
+	const transport: YorkieTransport | undefined =
+		options.secure === undefined ? undefined : options.secure ? "secure" : "insecure";
+	const endpoint: YorkieRpcEndpoint = normalizeYorkieRpcEndpoint(
+		options.rpcAddress ?? selectedSeedRpcAddress(seed) ?? "localhost:8080",
+		transport
+	);
+	assertSafeTransport(endpoint.rpcAddress, !endpoint.secure, options.allowInsecureRemote);
+
+	const actions: SetupAction[] = [];
+	const runner = new CommandRunner();
+	const yorkie = new YorkieCli(runner, endpoint.rpcAddress);
+	await yorkie.assertAvailable();
+
+	if (options.dryRun) {
+		actions.push(
+			{
+				id: "yorkie.login",
+				status: "planned",
+				message: `Log in to Yorkie at ${endpoint.rpcAddress}.`,
+			},
+			{
+				id: "yorkie.project",
+				status: "planned",
+				message: `Ensure Yorkie project ${options.projectName} exists.`,
+			},
+			{
+				id: "yorkie.webhook",
+				status: "planned",
+				message: `Configure the ${REQUIRED_EVENT} event webhook.`,
+			},
+			{
+				id: "env.backend",
+				status: "planned",
+				message: `Update ${backendEnvPath}.`,
+			},
+			{
+				id: "env.frontend",
+				status: "planned",
+				message: `Update ${frontendEnvPath}.`,
+			}
+		);
+		return {
+			command: "setup yorkie",
+			ok: true,
+			exitCode: EXIT_SUCCESS,
+			root,
+			dryRun: true,
+			changed: true,
+			actions,
+		};
+	}
+
+	await confirmMutation(
+		`Configure Yorkie project ${options.projectName} at ${endpoint.rpcAddress} and update two environment files?`,
+		options.yes,
+		runtime.disablePrompt
+	);
+	const password = options.passwordFromStdin
+		? await readPasswordFromStdin()
+		: environment("YORKIE_PASSWORD", "admin");
+	runner.addSecret(password);
+
+	await yorkie.login(options.username, password, !endpoint.secure);
+	actions.push({
+		id: "yorkie.login",
+		status: "unchanged",
+		message: `Authenticated to Yorkie at ${endpoint.rpcAddress}.`,
+	});
+
+	let projects = await yorkie.listProjects();
+	let project = findProject(projects, options.projectName);
+	let changed = false;
+	if (!project) {
+		await yorkie.createProject(options.projectName);
+		changed = true;
+		actions.push({
+			id: "yorkie.project",
+			status: "changed",
+			message: `Created Yorkie project ${options.projectName}.`,
+		});
+		projects = await yorkie.listProjects();
+		project = findProject(projects, options.projectName);
+	} else {
+		actions.push({
+			id: "yorkie.project",
+			status: "unchanged",
+			message: `Yorkie project ${options.projectName} already exists.`,
+		});
+	}
+
+	if (!project) {
+		throw new OperationalError(
+			`Yorkie project ${options.projectName} was not visible after creation.`,
+			"PROJECT_CREATION_FAILED"
+		);
+	}
+	const webhookNeedsUpdate =
+		project.eventWebhookUrl !== options.webhookUrl ||
+		!project.eventWebhookEvents.includes(REQUIRED_EVENT);
+	if (webhookNeedsUpdate) {
+		await yorkie.configureEventWebhook(options.projectName, options.webhookUrl);
+		changed = true;
+		actions.push({
+			id: "yorkie.webhook",
+			status: "changed",
+			message: `Configured the ${REQUIRED_EVENT} event webhook.`,
+		});
+	} else {
+		actions.push({
+			id: "yorkie.webhook",
+			status: "unchanged",
+			message: `The ${REQUIRED_EVENT} event webhook is already configured.`,
+		});
+	}
+
+	project = findProject(await yorkie.listProjects(), options.projectName);
+	assertProjectPostconditions(project, options.projectName, options.webhookUrl);
+	runner.addSecret(project.secretKey);
+
+	const backendUpdates: Readonly<Record<string, string>> = options.legacyEnvironmentKeysOnly
+		? { YORKIE_PROJECT_SECRET_KEY: project.secretKey }
+		: {
+				YORKIE_API_ADDR: endpoint.httpUrl,
+				YORKIE_PROJECT_SECRET_KEY: project.secretKey,
+			};
+	const frontendUpdates: Readonly<Record<string, string>> = options.legacyEnvironmentKeysOnly
+		? { VITE_YORKIE_API_KEY: project.publicKey }
+		: {
+				VITE_YORKIE_API_ADDR: endpoint.httpUrl,
+				VITE_YORKIE_API_KEY: project.publicKey,
+			};
+	const backendChanged = await updateEnvFileAtomic(backendEnvPath, backendUpdates, {
+		mode: 0o600,
+		initialContent: seed.backendInitialContent,
+	});
+	const frontendChanged = await updateEnvFileAtomic(frontendEnvPath, frontendUpdates, {
+		mode: 0o600,
+		initialContent: seed.frontendInitialContent,
+	});
+	changed ||= backendChanged || frontendChanged;
+	actions.push(
+		{
+			id: "env.backend",
+			status: backendChanged ? "changed" : "unchanged",
+			message: `${backendChanged ? "Updated" : "Verified"} backend environment file ${backendEnvPath}.`,
+		},
+		{
+			id: "env.frontend",
+			status: frontendChanged ? "changed" : "unchanged",
+			message: `${frontendChanged ? "Updated" : "Verified"} frontend environment file ${frontendEnvPath}.`,
+		}
+	);
+
+	if (!options.legacyEnvironmentKeysOnly) {
+		await verifyEnvValue(backendEnvPath, "YORKIE_API_ADDR", endpoint.httpUrl);
+		await verifyEnvValue(frontendEnvPath, "VITE_YORKIE_API_ADDR", endpoint.httpUrl);
+	}
+	await verifyEnvValue(backendEnvPath, "YORKIE_PROJECT_SECRET_KEY", project.secretKey);
+	await verifyEnvValue(frontendEnvPath, "VITE_YORKIE_API_KEY", project.publicKey);
+	actions.push({
+		id: "verify",
+		status: "unchanged",
+		message: "Verified Yorkie project, webhook, events, and environment files.",
+	});
+
+	return {
+		command: "setup yorkie",
+		ok: true,
+		exitCode: EXIT_SUCCESS,
+		root,
+		dryRun: false,
+		changed,
+		actions,
+	};
+}

--- a/packages/cli/src/core/args.ts
+++ b/packages/cli/src/core/args.ts
@@ -1,0 +1,65 @@
+import { UsageError } from "./errors.js";
+
+export interface GlobalOptions {
+	json: boolean;
+	help: boolean;
+	version: boolean;
+	root?: string;
+}
+
+export interface GlobalParseResult {
+	options: GlobalOptions;
+	remaining: string[];
+}
+
+function requireValue(tokens: readonly string[], index: number, option: string): string {
+	const value = tokens[index + 1];
+	if (!value || value.startsWith("-")) {
+		throw new UsageError(`${option} requires a value.`, "MISSING_OPTION_VALUE");
+	}
+	return value;
+}
+
+export function extractGlobalOptions(tokens: readonly string[]): GlobalParseResult {
+	const options: GlobalOptions = { json: false, help: false, version: false };
+	const remaining: string[] = [];
+
+	for (let index = 0; index < tokens.length; index += 1) {
+		const token = tokens[index];
+		if (token === "--json") {
+			options.json = true;
+		} else if (token === "--help" || token === "-h") {
+			options.help = true;
+		} else if (token === "--version" || token === "-V") {
+			options.version = true;
+		} else if (token === "--root") {
+			options.root = requireValue(tokens, index, token);
+			index += 1;
+		} else if (token?.startsWith("--root=")) {
+			const value = token.slice("--root=".length);
+			if (!value) throw new UsageError("--root requires a value.");
+			options.root = value;
+		} else if (token !== undefined) {
+			remaining.push(token);
+		}
+	}
+
+	return { options, remaining };
+}
+
+export function optionValue(
+	tokens: readonly string[],
+	index: number,
+	name: string
+): { value: string; consumed: number } | undefined {
+	const token = tokens[index];
+	if (token === name) {
+		return { value: requireValue(tokens, index, name), consumed: 2 };
+	}
+	if (token?.startsWith(`${name}=`)) {
+		const value = token.slice(name.length + 1);
+		if (!value) throw new UsageError(`${name} requires a value.`);
+		return { value, consumed: 1 };
+	}
+	return undefined;
+}

--- a/packages/cli/src/core/env-file.ts
+++ b/packages/cli/src/core/env-file.ts
@@ -1,0 +1,142 @@
+import { open, mkdir, readFile, rename, stat, unlink } from "node:fs/promises";
+import { basename, dirname, resolve } from "node:path";
+import { randomUUID } from "node:crypto";
+
+export interface ParsedEnvFile {
+	exists: boolean;
+	path: string;
+	values: Map<string, string>;
+	content: string;
+}
+
+const ENV_ASSIGNMENT = /^\s*(?:export\s+)?([A-Za-z_][A-Za-z0-9_]*)\s*=/;
+
+function decodeEnvValue(raw: string): string {
+	const trimmed = raw.trim();
+	if (trimmed.startsWith('"') && trimmed.endsWith('"')) {
+		try {
+			return JSON.parse(trimmed) as string;
+		} catch {
+			return trimmed.slice(1, -1);
+		}
+	}
+	if (trimmed.startsWith("'") && trimmed.endsWith("'")) {
+		return trimmed.slice(1, -1);
+	}
+	return trimmed.replace(/\s+#.*$/, "").trim();
+}
+
+export function parseEnv(content: string): Map<string, string> {
+	const values = new Map<string, string>();
+	for (const line of content.split(/\r?\n/)) {
+		const match = ENV_ASSIGNMENT.exec(line);
+		if (!match?.[1]) continue;
+		const equalsIndex = line.indexOf("=");
+		values.set(match[1], decodeEnvValue(line.slice(equalsIndex + 1)));
+	}
+	return values;
+}
+
+export async function readEnv(path: string): Promise<ParsedEnvFile> {
+	const absolutePath = resolve(path);
+	try {
+		const content = await readFile(absolutePath, "utf8");
+		return {
+			exists: true,
+			path: absolutePath,
+			values: parseEnv(content),
+			content,
+		};
+	} catch (error) {
+		if ((error as NodeJS.ErrnoException).code === "ENOENT") {
+			return {
+				exists: false,
+				path: absolutePath,
+				values: new Map<string, string>(),
+				content: "",
+			};
+		}
+		throw error;
+	}
+}
+
+function quoteEnvValue(value: string): string {
+	return JSON.stringify(value);
+}
+
+export function updateEnvContent(
+	content: string,
+	updates: Readonly<Record<string, string>>
+): string {
+	for (const key of Object.keys(updates)) {
+		if (!/^[A-Za-z_][A-Za-z0-9_]*$/.test(key)) {
+			throw new Error(`Invalid environment variable name: ${key}`);
+		}
+	}
+
+	const newline = content.includes("\r\n") ? "\r\n" : "\n";
+	const hadTrailingNewline = content.endsWith("\n");
+	const lines = content.length > 0 ? content.split(/\r?\n/) : [];
+	if (hadTrailingNewline) lines.pop();
+	const remaining = new Set(Object.keys(updates));
+	const seen = new Set<string>();
+	const output: string[] = [];
+
+	for (const line of lines) {
+		const match = ENV_ASSIGNMENT.exec(line);
+		const key = match?.[1];
+		if (!key || !(key in updates)) {
+			output.push(line);
+			continue;
+		}
+		if (seen.has(key)) continue;
+		seen.add(key);
+		remaining.delete(key);
+		output.push(`${key}=${quoteEnvValue(updates[key] ?? "")}`);
+	}
+
+	if (remaining.size > 0 && output.length > 0 && output.at(-1) !== "") {
+		output.push("");
+	}
+	for (const key of remaining) {
+		output.push(`${key}=${quoteEnvValue(updates[key] ?? "")}`);
+	}
+
+	if (output.length === 0) return "";
+	return `${output.join(newline)}${newline}`;
+}
+
+export async function updateEnvFileAtomic(
+	path: string,
+	updates: Readonly<Record<string, string>>,
+	options: { mode?: number; initialContent?: string } = {}
+): Promise<boolean> {
+	const absolutePath = resolve(path);
+	const existing = await readEnv(absolutePath);
+	const content = existing.exists ? existing.content : (options.initialContent ?? "");
+	const updated = updateEnvContent(content, updates);
+	if (existing.exists && updated === content) return false;
+
+	await mkdir(dirname(absolutePath), { recursive: true });
+	let mode = options.mode ?? 0o600;
+	if (existing.exists && options.mode === undefined) {
+		mode = (await stat(absolutePath)).mode & 0o777;
+	}
+	const temporaryPath = resolve(
+		dirname(absolutePath),
+		`.${basename(absolutePath)}.${process.pid}.${randomUUID()}.tmp`
+	);
+	const handle = await open(temporaryPath, "wx", mode);
+	try {
+		await handle.writeFile(updated, "utf8");
+		await handle.sync();
+		await handle.chmod(mode);
+		await handle.close();
+		await rename(temporaryPath, absolutePath);
+	} catch (error) {
+		await handle.close().catch(() => undefined);
+		await unlink(temporaryPath).catch(() => undefined);
+		throw error;
+	}
+	return true;
+}

--- a/packages/cli/src/core/errors.ts
+++ b/packages/cli/src/core/errors.ts
@@ -1,0 +1,60 @@
+import { EXIT_FAILURE, EXIT_USAGE, type ExitCode } from "../types.js";
+
+export class CliError extends Error {
+	readonly code: string;
+	readonly exitCode: ExitCode;
+
+	constructor(message: string, code: string, exitCode: ExitCode, options?: ErrorOptions) {
+		super(message, options);
+		this.name = "CliError";
+		this.code = code;
+		this.exitCode = exitCode;
+	}
+}
+
+export class UsageError extends CliError {
+	constructor(message: string, code = "INVALID_USAGE", options?: ErrorOptions) {
+		super(message, code, EXIT_USAGE, options);
+		this.name = "UsageError";
+	}
+}
+
+export class SafetyError extends CliError {
+	constructor(message: string, code = "UNSAFE_CONFIGURATION", options?: ErrorOptions) {
+		super(message, code, EXIT_USAGE, options);
+		this.name = "SafetyError";
+	}
+}
+
+export class ConfirmationRequiredError extends CliError {
+	constructor(message = "Non-interactive setup requires --yes.") {
+		super(message, "CONFIRMATION_REQUIRED", EXIT_USAGE);
+		this.name = "ConfirmationRequiredError";
+	}
+}
+
+export class ConfirmationDeclinedError extends CliError {
+	constructor(message = "Setup cancelled by user.") {
+		super(message, "CONFIRMATION_DECLINED", EXIT_FAILURE);
+		this.name = "ConfirmationDeclinedError";
+	}
+}
+
+export class OperationalError extends CliError {
+	constructor(message: string, code = "OPERATION_FAILED", options?: ErrorOptions) {
+		super(message, code, EXIT_FAILURE, options);
+		this.name = "OperationalError";
+	}
+}
+
+export function toCliError(error: unknown): CliError {
+	if (error instanceof CliError) {
+		return error;
+	}
+	if (error instanceof Error) {
+		return new OperationalError(error.message, "UNEXPECTED_ERROR", {
+			cause: error,
+		});
+	}
+	return new OperationalError(String(error), "UNEXPECTED_ERROR");
+}

--- a/packages/cli/src/core/output.ts
+++ b/packages/cli/src/core/output.ts
@@ -1,0 +1,57 @@
+import { redactValue } from "./redact.js";
+import type { DoctorCheck, DoctorResult, ErrorResult, SetupResult } from "../types.js";
+
+export type ResultEnvelope = DoctorResult | SetupResult | ErrorResult;
+
+function checkMarker(check: DoctorCheck): string {
+	switch (check.status) {
+		case "pass":
+			return "PASS";
+		case "warn":
+			return "WARN";
+		case "fail":
+			return "FAIL";
+		case "skip":
+			return "SKIP";
+	}
+}
+
+export function writeResult(
+	result: ResultEnvelope,
+	json: boolean,
+	secrets: Iterable<string> = []
+): void {
+	if (json) {
+		process.stdout.write(`${JSON.stringify(redactValue(result, secrets), null, 2)}\n`);
+		return;
+	}
+
+	if (result.command === "doctor" && "checks" in result) {
+		process.stdout.write(`CodePair doctor (${result.root})\n`);
+		for (const check of result.checks) {
+			process.stdout.write(`[${checkMarker(check)}] ${check.message}\n`);
+			if ((check.status === "warn" || check.status === "fail") && check.remediation) {
+				process.stdout.write(`       ${check.remediation}\n`);
+			}
+		}
+		process.stdout.write(
+			`Summary: ${result.summary.pass} passed, ${result.summary.warn} warnings, ${result.summary.fail} failed, ${result.summary.skip} skipped\n`
+		);
+		return;
+	}
+
+	if (result.command === "setup yorkie" && "actions" in result) {
+		process.stdout.write(
+			`${result.dryRun ? "CodePair Yorkie setup plan" : "CodePair Yorkie setup"} (${result.root})\n`
+		);
+		for (const action of result.actions) {
+			process.stdout.write(`[${action.status.toUpperCase()}] ${action.message}\n`);
+		}
+		process.stdout.write(result.ok ? "Yorkie setup complete.\n" : "Yorkie setup failed.\n");
+		return;
+	}
+
+	if ("error" in result) {
+		process.stderr.write(`${result.error.message}\n`);
+	}
+}

--- a/packages/cli/src/core/process.ts
+++ b/packages/cli/src/core/process.ts
@@ -1,0 +1,201 @@
+import { spawn } from "node:child_process";
+import { OperationalError } from "./errors.js";
+import { redactCommandArgs, redactText } from "./redact.js";
+
+const DEFAULT_TIMEOUT_MS = 15_000;
+const TERMINATION_GRACE_MS = 250;
+const MAX_CAPTURE_BYTES = 4 * 1024 * 1024;
+
+export interface CommandResult {
+	command: string;
+	args: string[];
+	exitCode: number;
+	stdout: string;
+	stderr: string;
+}
+
+export interface RunCommandOptions {
+	cwd?: string;
+	env?: NodeJS.ProcessEnv;
+	input?: string;
+	timeoutMs?: number;
+	allowFailure?: boolean;
+}
+
+export class CommandRunner {
+	readonly #secrets = new Set<string>();
+
+	addSecret(secret: string | undefined): void {
+		if (secret) {
+			this.#secrets.add(secret);
+		}
+	}
+
+	get secrets(): ReadonlySet<string> {
+		return this.#secrets;
+	}
+
+	async run(
+		command: string,
+		args: readonly string[],
+		options: RunCommandOptions = {}
+	): Promise<CommandResult> {
+		const timeoutMs = options.timeoutMs ?? DEFAULT_TIMEOUT_MS;
+		return await new Promise<CommandResult>((resolve, reject) => {
+			let stdout = "";
+			let stderr = "";
+			let settled = false;
+			let timedOut = false;
+			let timeoutTimer: NodeJS.Timeout | undefined;
+			let terminationTimer: NodeJS.Timeout | undefined;
+
+			const child = spawn(command, [...args], {
+				cwd: options.cwd,
+				env: options.env ?? process.env,
+				shell: false,
+				windowsHide: true,
+				stdio: ["pipe", "pipe", "pipe"],
+			});
+
+			child.stdout.setEncoding("utf8");
+			child.stderr.setEncoding("utf8");
+			const captureStdout = (chunk: string): void => {
+				if (stdout.length < MAX_CAPTURE_BYTES) {
+					stdout += chunk.slice(0, MAX_CAPTURE_BYTES - stdout.length);
+				}
+			};
+			const captureStderr = (chunk: string): void => {
+				if (stderr.length < MAX_CAPTURE_BYTES) {
+					stderr += chunk.slice(0, MAX_CAPTURE_BYTES - stderr.length);
+				}
+			};
+			child.stdout.on("data", captureStdout);
+			child.stderr.on("data", captureStderr);
+			// A child may close stdin before the provided input is flushed. Its exit event
+			// remains the authoritative command result, so an EPIPE must not be unhandled.
+			child.stdin.on("error", () => undefined);
+
+			const clearTimers = (): void => {
+				if (timeoutTimer !== undefined) {
+					clearTimeout(timeoutTimer);
+					timeoutTimer = undefined;
+				}
+				if (terminationTimer !== undefined) {
+					clearTimeout(terminationTimer);
+					terminationTimer = undefined;
+				}
+			};
+
+			const stopCapturing = (): void => {
+				child.stdout.off("data", captureStdout);
+				child.stderr.off("data", captureStderr);
+			};
+
+			const timeoutError = (): OperationalError => {
+				const display = [command, ...redactCommandArgs(args)].join(" ");
+				return new OperationalError(
+					redactText(`Command timed out after ${timeoutMs}ms: ${display}`, this.#secrets),
+					"COMMAND_TIMEOUT"
+				);
+			};
+
+			const forceSettleTimeout = (): void => {
+				if (settled) return;
+				settled = true;
+				clearTimers();
+				stopCapturing();
+				child.stdin.destroy();
+				child.stdout.destroy();
+				child.stderr.destroy();
+				child.unref();
+				reject(timeoutError());
+			};
+
+			timeoutTimer = setTimeout(() => {
+				if (settled) return;
+				timedOut = true;
+				try {
+					child.kill("SIGTERM");
+				} catch {
+					// The escalation timer below still guarantees settlement.
+				}
+				terminationTimer = setTimeout(() => {
+					if (settled) return;
+					try {
+						child.kill("SIGKILL");
+					} catch {
+						// Releasing the child handle below prevents an unkillable child from
+						// keeping the caller or event loop waiting indefinitely.
+					}
+					forceSettleTimeout();
+				}, TERMINATION_GRACE_MS);
+				terminationTimer.unref();
+			}, timeoutMs);
+			timeoutTimer.unref();
+
+			child.once("error", (error) => {
+				if (settled) return;
+				settled = true;
+				clearTimers();
+				stopCapturing();
+				child.stdin.destroy();
+				child.stdout.destroy();
+				child.stderr.destroy();
+				child.unref();
+				const display = [command, ...redactCommandArgs(args)].join(" ");
+				reject(
+					new OperationalError(
+						redactText(`Unable to run ${display}: ${error.message}`, this.#secrets),
+						"COMMAND_NOT_AVAILABLE",
+						{ cause: error }
+					)
+				);
+			});
+
+			child.once("close", (code, signal) => {
+				if (settled) return;
+				settled = true;
+				clearTimers();
+				stopCapturing();
+				child.stdin.destroy();
+				const exitCode = code ?? 1;
+				const result: CommandResult = {
+					command,
+					args: [...args],
+					exitCode,
+					stdout,
+					stderr,
+				};
+
+				if (timedOut) {
+					reject(timeoutError());
+					return;
+				}
+
+				if (exitCode !== 0 && !options.allowFailure) {
+					const diagnostic =
+						stderr.trim() || stdout.trim() || `signal ${signal ?? "unknown"}`;
+					const display = [command, ...redactCommandArgs(args)].join(" ");
+					reject(
+						new OperationalError(
+							redactText(
+								`Command failed (${exitCode}): ${display}\n${diagnostic}`,
+								this.#secrets
+							),
+							"COMMAND_FAILED"
+						)
+					);
+					return;
+				}
+
+				resolve(result);
+			});
+
+			if (options.input !== undefined) {
+				child.stdin.end(options.input);
+			} else {
+				child.stdin.end();
+			}
+		});
+	}
+}

--- a/packages/cli/src/core/project-root.ts
+++ b/packages/cli/src/core/project-root.ts
@@ -1,0 +1,85 @@
+import { access, readFile, realpath } from "node:fs/promises";
+import { constants } from "node:fs";
+import { dirname, isAbsolute, parse, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import { UsageError } from "./errors.js";
+
+export function resolveProjectPath(
+	root: string,
+	configuredPath: string | undefined,
+	fallback: readonly string[]
+): string {
+	if (!configuredPath) return resolve(root, ...fallback);
+	return isAbsolute(configuredPath) ? configuredPath : resolve(root, configuredPath);
+}
+
+async function exists(path: string): Promise<boolean> {
+	try {
+		await access(path, constants.F_OK);
+		return true;
+	} catch {
+		return false;
+	}
+}
+
+export async function isCodePairRoot(candidate: string): Promise<boolean> {
+	const packagePath = resolve(candidate, "package.json");
+	if (
+		!(await exists(packagePath)) ||
+		!(await exists(resolve(candidate, "pnpm-workspace.yaml"))) ||
+		!(await exists(resolve(candidate, "packages", "backend"))) ||
+		!(await exists(resolve(candidate, "packages", "frontend")))
+	) {
+		return false;
+	}
+
+	try {
+		const parsed = JSON.parse(await readFile(packagePath, "utf8")) as {
+			name?: unknown;
+		};
+		return parsed.name === "codepair";
+	} catch {
+		return false;
+	}
+}
+
+async function searchUp(start: string): Promise<string | undefined> {
+	let current = resolve(start);
+	const root = parse(current).root;
+	while (true) {
+		if (await isCodePairRoot(current)) {
+			return await realpath(current);
+		}
+		if (current === root) return undefined;
+		current = dirname(current);
+	}
+}
+
+export async function discoverProjectRoot(explicitRoot?: string): Promise<string> {
+	if (explicitRoot) {
+		const candidate = resolve(explicitRoot);
+		if (!(await isCodePairRoot(candidate))) {
+			throw new UsageError(
+				`${candidate} is not a CodePair project root (expected package.json, pnpm-workspace.yaml, packages/backend, and packages/frontend).`,
+				"INVALID_PROJECT_ROOT"
+			);
+		}
+		return await realpath(candidate);
+	}
+
+	const environmentRoot = process.env.CODEPAIR_ROOT;
+	if (environmentRoot) {
+		return await discoverProjectRoot(environmentRoot);
+	}
+
+	const moduleDirectory = dirname(fileURLToPath(import.meta.url));
+	for (const start of [process.cwd(), moduleDirectory]) {
+		const found = await searchUp(start);
+		if (found) return found;
+	}
+
+	throw new UsageError(
+		"Could not find a CodePair project root. Run inside the repository or pass --root PATH.",
+		"PROJECT_ROOT_NOT_FOUND"
+	);
+}

--- a/packages/cli/src/core/prompt.ts
+++ b/packages/cli/src/core/prompt.ts
@@ -1,0 +1,53 @@
+import { createInterface } from "node:readline/promises";
+import { ConfirmationDeclinedError, ConfirmationRequiredError, UsageError } from "./errors.js";
+
+export async function confirmMutation(
+	message: string,
+	assumeYes: boolean,
+	disablePrompt = false
+): Promise<void> {
+	if (assumeYes) return;
+	if (disablePrompt || !process.stdin.isTTY || !process.stdout.isTTY) {
+		throw new ConfirmationRequiredError();
+	}
+
+	const readline = createInterface({
+		input: process.stdin,
+		output: process.stdout,
+	});
+	try {
+		const answer = (await readline.question(`${message} [y/N] `)).trim().toLowerCase();
+		if (answer !== "y" && answer !== "yes") {
+			throw new ConfirmationDeclinedError();
+		}
+	} finally {
+		readline.close();
+	}
+}
+
+export async function readPasswordFromStdin(): Promise<string> {
+	if (process.stdin.isTTY) {
+		throw new UsageError(
+			"--password-stdin expects piped input. Use YORKIE_PASSWORD for an interactive shell.",
+			"PASSWORD_STDIN_IS_TTY"
+		);
+	}
+
+	const chunks: Buffer[] = [];
+	let total = 0;
+	for await (const chunk of process.stdin) {
+		const buffer = Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk as string);
+		total += buffer.length;
+		if (total > 64 * 1024) {
+			throw new UsageError("Password input is unexpectedly large.", "PASSWORD_TOO_LARGE");
+		}
+		chunks.push(buffer);
+	}
+	const password = Buffer.concat(chunks)
+		.toString("utf8")
+		.replace(/[\r\n]+$/, "");
+	if (!password) {
+		throw new UsageError("Password from stdin is empty.", "EMPTY_PASSWORD");
+	}
+	return password;
+}

--- a/packages/cli/src/core/redact.ts
+++ b/packages/cli/src/core/redact.ts
@@ -1,0 +1,77 @@
+const SENSITIVE_KEY =
+	/(?:password|passwd|secret|authorization|credential|private[_-]?key|access[_-]?token|refresh[_-]?token|api[_-]?key)/i;
+
+export const REDACTED = "[REDACTED]";
+
+export function redactText(value: string, secrets: Iterable<string> = []): string {
+	let result = value;
+	const orderedSecrets = [...secrets]
+		.filter((secret) => secret.length > 0)
+		.sort((left, right) => right.length - left.length);
+
+	for (const secret of orderedSecrets) {
+		result = result.split(secret).join(REDACTED);
+	}
+
+	result = result.replace(
+		/((?:password|passwd|secret|authorization|credential|private[_-]?key|access[_-]?token|refresh[_-]?token|api[_-]?key|token)\s*[=:]\s*)([^\s,;]+)/gi,
+		`$1${REDACTED}`
+	);
+	return result;
+}
+
+export function redactCommandArgs(args: readonly string[]): string[] {
+	const result: string[] = [];
+	let redactNext = false;
+	for (const arg of args) {
+		if (redactNext) {
+			result.push(REDACTED);
+			redactNext = false;
+			continue;
+		}
+		if (arg === "-p" || arg === "--password" || arg === "--token") {
+			result.push(arg);
+			redactNext = true;
+			continue;
+		}
+		if (/^--(?:password|token)=/i.test(arg)) {
+			result.push(`${arg.slice(0, arg.indexOf("=") + 1)}${REDACTED}`);
+			continue;
+		}
+		result.push(arg);
+	}
+	return result;
+}
+
+export function redactValue(value: unknown, secrets: Iterable<string> = []): unknown {
+	return redactValueInternal(value, secrets, new WeakSet<object>());
+}
+
+function redactValueInternal(
+	value: unknown,
+	secrets: Iterable<string>,
+	seen: WeakSet<object>
+): unknown {
+	if (typeof value === "string") {
+		return redactText(value, secrets);
+	}
+	if (value === null || typeof value !== "object") {
+		return value;
+	}
+	if (seen.has(value)) {
+		return "[Circular]";
+	}
+	seen.add(value);
+
+	if (Array.isArray(value)) {
+		return value.map((entry) => redactValueInternal(entry, secrets, seen));
+	}
+
+	const output: Record<string, unknown> = {};
+	for (const [key, entry] of Object.entries(value)) {
+		output[key] = SENSITIVE_KEY.test(key)
+			? REDACTED
+			: redactValueInternal(entry, secrets, seen);
+	}
+	return output;
+}

--- a/packages/cli/src/core/url.ts
+++ b/packages/cli/src/core/url.ts
@@ -1,0 +1,120 @@
+import { SafetyError, UsageError } from "./errors.js";
+
+export type YorkieTransport = "secure" | "insecure";
+
+export interface YorkieRpcEndpoint {
+	rpcAddress: string;
+	httpUrl: string;
+	secure: boolean;
+}
+
+const URL_SCHEME = /^[A-Za-z][A-Za-z\d+.-]*:\/\//;
+
+function requestedScheme(transport: YorkieTransport | undefined): "http:" | "https:" | undefined {
+	if (transport === "secure") return "https:";
+	if (transport === "insecure") return "http:";
+	return undefined;
+}
+
+export function normalizeYorkieRpcEndpoint(
+	value: string,
+	transport?: YorkieTransport
+): YorkieRpcEndpoint {
+	const trimmed = value.trim();
+	if (!trimmed) throw new UsageError("--rpc-addr must not be empty.");
+
+	const hasScheme = URL_SCHEME.test(trimmed);
+	let parsed: URL;
+	try {
+		parsed = new URL(hasScheme ? trimmed : `http://${trimmed}`);
+	} catch (error) {
+		throw new UsageError("Invalid Yorkie RPC address.", "INVALID_RPC_ADDRESS", {
+			cause: error,
+		});
+	}
+
+	if (parsed.protocol !== "http:" && parsed.protocol !== "https:") {
+		throw new UsageError("Yorkie RPC address must use http or https.", "INVALID_RPC_ADDRESS");
+	}
+	if (parsed.username || parsed.password) {
+		throw new SafetyError(
+			"Yorkie RPC address must not contain credentials.",
+			"RPC_CREDENTIALS_REFUSED"
+		);
+	}
+	if (parsed.pathname !== "/" || parsed.search || parsed.hash) {
+		throw new UsageError(
+			"Yorkie RPC address must contain only a host and port.",
+			"INVALID_RPC_ADDRESS"
+		);
+	}
+
+	const explicitScheme = hasScheme ? parsed.protocol : undefined;
+	const expectedScheme = requestedScheme(transport);
+	if (explicitScheme && expectedScheme && explicitScheme !== expectedScheme) {
+		const option = transport === "secure" ? "--secure" : "--insecure";
+		throw new UsageError(
+			`${option} conflicts with the ${explicitScheme.slice(0, -1)} scheme in --rpc-addr.`,
+			"CONFLICTING_TRANSPORT_OPTIONS"
+		);
+	}
+
+	const scheme = explicitScheme ?? expectedScheme ?? "http:";
+	const port = parsed.port || (hasScheme ? (scheme === "https:" ? "443" : "80") : "8080");
+	const rpcAddress = `${parsed.hostname}:${port}`;
+	return {
+		rpcAddress,
+		httpUrl: `${scheme}//${rpcAddress}`,
+		secure: scheme === "https:",
+	};
+}
+
+export function getRpcHost(rpcAddress: string): string {
+	return normalizeYorkieRpcEndpoint(rpcAddress).rpcAddress.replace(/:\d+$/, "");
+}
+
+export function isLoopbackHost(hostname: string): boolean {
+	const host = hostname.replace(/^\[|\]$/g, "").toLowerCase();
+	return (
+		host === "localhost" ||
+		host.endsWith(".localhost") ||
+		host === "::1" ||
+		host === "0:0:0:0:0:0:0:1" ||
+		/^127(?:\.\d{1,3}){3}$/.test(host)
+	);
+}
+
+export function assertSafeTransport(
+	rpcAddress: string,
+	insecure: boolean,
+	allowInsecureRemote: boolean
+): void {
+	const host = getRpcHost(rpcAddress);
+	if (insecure && !isLoopbackHost(host) && !allowInsecureRemote) {
+		throw new SafetyError(
+			`Refusing an insecure Yorkie login to non-loopback host ${host}. Use --secure, or explicitly pass --allow-insecure-remote if this is a trusted private network.`,
+			"INSECURE_REMOTE_REFUSED"
+		);
+	}
+}
+
+export function validateWebhookUrl(value: string): URL {
+	let parsed: URL;
+	try {
+		parsed = new URL(value);
+	} catch (error) {
+		throw new UsageError("Invalid webhook URL.", "INVALID_WEBHOOK_URL", {
+			cause: error,
+		});
+	}
+	if (parsed.protocol !== "http:" && parsed.protocol !== "https:") {
+		throw new UsageError("Webhook URL must use http or https.", "INVALID_WEBHOOK_URL");
+	}
+	if (parsed.username || parsed.password) {
+		throw new SafetyError(
+			"Webhook URL must not contain credentials. Configure authentication separately.",
+			"WEBHOOK_CREDENTIALS_REFUSED"
+		);
+	}
+	return parsed;
+}

--- a/packages/cli/src/help.ts
+++ b/packages/cli/src/help.ts
@@ -1,0 +1,63 @@
+export const MAIN_HELP = `CodePair developer CLI
+
+Usage:
+  codepair setup yorkie [options]
+  codepair doctor [options]
+  codepair help [command]
+  codepair version
+
+Global options:
+  --root PATH       CodePair repository root (or CODEPAIR_ROOT)
+  --json            Emit one structured JSON document
+  -h, --help        Show help
+  -V, --version     Show version
+
+Commands:
+  setup yorkie      Configure the Yorkie project, event webhook, and env keys
+  doctor            Diagnose the local CodePair toolchain and services
+`;
+
+export const SETUP_HELP = `Configure Yorkie for a CodePair development environment.
+
+Usage:
+  codepair setup yorkie [options]
+
+Options:
+  --rpc-addr ADDRESS          Yorkie RPC address (default: localhost:8080)
+  --project NAME             Yorkie project name (default: codepair)
+  --username NAME            Yorkie administrator username (default: admin)
+  --password-stdin           Read the Yorkie password from standard input
+  --webhook-url URL          DocumentRootChanged event webhook URL
+  --backend-env PATH         Backend .env.development path
+  --frontend-env PATH        Frontend .env.development path
+  --secure                   Use TLS; omit Yorkie's --insecure flag
+  --insecure                 Use plaintext transport (the local default)
+  --allow-insecure-remote    Allow plaintext login to a non-loopback host
+  -y, --yes                  Confirm mutations (required when non-interactive)
+  --dry-run                  Validate and print the mutation plan only
+  --root PATH                CodePair repository root
+  --json                     Emit one structured JSON document
+`;
+
+export const DOCTOR_HELP = `Diagnose a CodePair development environment without changing server state.
+
+Usage:
+  codepair doctor [options]
+
+Options:
+  --scope SCOPE              all, toolchain, env, services, or yorkie (default: all)
+  --strict                   Treat warnings as failures
+  --rpc-addr ADDRESS         Expected Yorkie RPC address (default: env or localhost:8080)
+  --project NAME             Expected Yorkie project name (default: env or codepair)
+  --webhook-url URL          Expected DocumentRootChanged webhook URL
+  --backend-env PATH         Backend environment file path
+  --frontend-env PATH        Frontend environment file path
+  --root PATH                CodePair repository root
+  --json                     Emit one structured JSON document
+`;
+
+export function helpFor(tokens: readonly string[]): string {
+	if (tokens[0] === "setup" && tokens[1] === "yorkie") return SETUP_HELP;
+	if (tokens[0] === "doctor") return DOCTOR_HELP;
+	return MAIN_HELP;
+}

--- a/packages/cli/src/main.ts
+++ b/packages/cli/src/main.ts
@@ -1,0 +1,88 @@
+import { readFile } from "node:fs/promises";
+import { extractGlobalOptions } from "./core/args.js";
+import { UsageError, toCliError } from "./core/errors.js";
+import { writeResult } from "./core/output.js";
+import { redactText } from "./core/redact.js";
+import { parseDoctorOptions, runDoctor } from "./commands/doctor.js";
+import { parseSetupYorkieOptions, runSetupYorkie } from "./commands/setup-yorkie.js";
+import { helpFor, MAIN_HELP } from "./help.js";
+import type { ErrorResult, ExitCode } from "./types.js";
+
+export async function packageVersion(): Promise<string> {
+	const packageUrl = new URL("../package.json", import.meta.url);
+	const parsed = JSON.parse(await readFile(packageUrl, "utf8")) as {
+		version?: unknown;
+	};
+	if (typeof parsed.version !== "string") throw new Error("CLI package version is missing.");
+	return parsed.version;
+}
+
+function commandLabel(tokens: readonly string[]): string {
+	if (tokens[0] === "setup" && tokens[1] === "yorkie") return "setup yorkie";
+	return tokens[0] ?? "codepair";
+}
+
+export async function runCli(argv: readonly string[]): Promise<ExitCode> {
+	let json = argv.includes("--json");
+	let remaining: string[] = [...argv];
+	try {
+		const parsed = extractGlobalOptions(argv);
+		json = parsed.options.json;
+		remaining = parsed.remaining;
+
+		if (parsed.options.version || remaining[0] === "version") {
+			process.stdout.write(`${await packageVersion()}\n`);
+			return 0;
+		}
+
+		if (remaining[0] === "help") {
+			process.stdout.write(helpFor(remaining.slice(1)));
+			return 0;
+		}
+
+		if (parsed.options.help) {
+			process.stdout.write(helpFor(remaining));
+			return 0;
+		}
+
+		if (remaining.length === 0) {
+			process.stdout.write(MAIN_HELP);
+			return 0;
+		}
+
+		if (remaining[0] === "doctor") {
+			const result = await runDoctor(
+				parseDoctorOptions(remaining.slice(1), parsed.options.root)
+			);
+			writeResult(result, json);
+			return result.exitCode;
+		}
+
+		if (remaining[0] === "setup" && remaining[1] === "yorkie") {
+			const result = await runSetupYorkie(
+				parseSetupYorkieOptions(remaining.slice(2), parsed.options.root),
+				{ disablePrompt: parsed.options.json }
+			);
+			writeResult(result, json);
+			return result.exitCode;
+		}
+
+		if (remaining[0] === "setup") {
+			throw new UsageError("Unknown setup target. Expected: codepair setup yorkie");
+		}
+		throw new UsageError(`Unknown command: ${remaining[0]}`, "UNKNOWN_COMMAND");
+	} catch (error) {
+		const cliError = toCliError(error);
+		const result: ErrorResult = {
+			command: commandLabel(remaining),
+			ok: false,
+			exitCode: cliError.exitCode,
+			error: {
+				code: cliError.code,
+				message: redactText(cliError.message),
+			},
+		};
+		writeResult(result, json);
+		return cliError.exitCode;
+	}
+}

--- a/packages/cli/src/types.ts
+++ b/packages/cli/src/types.ts
@@ -1,0 +1,63 @@
+export const EXIT_SUCCESS = 0 as const;
+export const EXIT_FAILURE = 1 as const;
+export const EXIT_USAGE = 2 as const;
+
+export type ExitCode = typeof EXIT_SUCCESS | typeof EXIT_FAILURE | typeof EXIT_USAGE;
+
+export type CheckScope = "toolchain" | "env" | "services" | "yorkie";
+export type RequestedScope = CheckScope | "all";
+export type CheckStatus = "pass" | "warn" | "fail" | "skip";
+
+export interface DoctorCheck {
+	id: string;
+	scope: CheckScope;
+	status: CheckStatus;
+	message: string;
+	details?: Record<string, unknown>;
+	remediation?: string;
+}
+
+export interface DoctorSummary {
+	pass: number;
+	warn: number;
+	fail: number;
+	skip: number;
+}
+
+export interface DoctorResult {
+	command: "doctor";
+	ok: boolean;
+	exitCode: ExitCode;
+	root: string;
+	strict: boolean;
+	checks: DoctorCheck[];
+	summary: DoctorSummary;
+}
+
+export type SetupActionStatus = "changed" | "unchanged" | "planned";
+
+export interface SetupAction {
+	id: string;
+	status: SetupActionStatus;
+	message: string;
+}
+
+export interface SetupResult {
+	command: "setup yorkie";
+	ok: boolean;
+	exitCode: ExitCode;
+	root: string;
+	dryRun: boolean;
+	changed: boolean;
+	actions: SetupAction[];
+}
+
+export interface ErrorResult {
+	command: string;
+	ok: false;
+	exitCode: ExitCode;
+	error: {
+		code: string;
+		message: string;
+	};
+}

--- a/packages/cli/test/e2e/cli.test.mjs
+++ b/packages/cli/test/e2e/cli.test.mjs
@@ -1,0 +1,297 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+	createCodePairRoot,
+	createFakeToolchain,
+	existingProject,
+	parseSingleJson,
+	readCliPackage,
+	runCli,
+	writeEnvFiles,
+} from "./helpers/cli-harness.mjs";
+
+test("top-level help documents the stable command surface", () => {
+	for (const args of [["--help"], ["-h"], ["help"]]) {
+		const result = runCli(args);
+		assert.equal(result.status, 0, `${args.join(" ")} failed: ${result.stderr}`);
+		assert.equal(result.stderr, "");
+		assert.match(result.stdout, /Usage:\s+codepair/i);
+		assert.match(result.stdout, /doctor/);
+		assert.match(result.stdout, /setup\s+yorkie/);
+		assert.match(result.stdout, /--version/);
+	}
+});
+
+test("version flags and command report the package version", () => {
+	const expected = readCliPackage().version;
+	for (const args of [["--version"], ["-V"], ["version"]]) {
+		const result = runCli(args);
+		assert.equal(result.status, 0, `${args.join(" ")} failed: ${result.stderr}`);
+		assert.equal(result.stderr, "");
+		assert.equal(result.stdout.trim(), expected);
+	}
+});
+
+test("invalid command and options use the usage exit code", () => {
+	for (const args of [
+		["definitely-not-a-command"],
+		["doctor", "--scope", "nope"],
+		["doctor", "--scope"],
+		["setup", "not-yorkie"],
+		["setup", "yorkie", "--definitely-not-an-option"],
+		["setup", "yorkie", "--secure", "--insecure"],
+	]) {
+		const result = runCli(args);
+		assert.equal(result.status, 2, `${args.join(" ")} should be invalid usage`);
+		assert.notEqual(result.stderr.trim(), "");
+	}
+});
+
+test("JSON usage errors are one machine-readable document", () => {
+	const result = runCli(["--json", "doctor", "--scope", "invalid"]);
+	assert.equal(result.status, 2);
+	const output = parseSingleJson(result);
+	assert.equal(output.ok, false);
+	assert.equal(output.exitCode, 2);
+	assert.equal(output.command, "doctor");
+	assert.equal(typeof output.error?.code, "string");
+	assert.equal(typeof output.error?.message, "string");
+});
+
+test("JSON usage errors do not echo credentials from malformed URLs", () => {
+	for (const [option, value] of [
+		["--rpc-addr", "http://alice:rpc-secret@["],
+		["--webhook-url", "http://alice:webhook-secret@["],
+	]) {
+		const result = runCli(["setup", "yorkie", option, value, "--json"]);
+		assert.equal(result.status, 2);
+		parseSingleJson(result);
+		assert.doesNotMatch(result.stdout, /alice|secret/);
+	}
+});
+
+test("unknown-command diagnostics never echo trailing secret arguments", () => {
+	const secret = "must-not-appear-in-output";
+	for (const args of [
+		["not-a-command", "--password", secret, "--json"],
+		["--password", secret, "--json"],
+		[`--token=${secret}`, "--json"],
+		["setup", "yorkie", `--credential=${secret}`, "--json"],
+	]) {
+		const result = runCli(args);
+		assert.equal(result.status, 2);
+		parseSingleJson(result);
+		assert.doesNotMatch(result.stdout, new RegExp(secret));
+	}
+});
+
+test("doctor toolchain emits a complete JSON envelope and accepts global flags anywhere", (t) => {
+	const root = createCodePairRoot(t, "doctor json");
+	const fake = createFakeToolchain(t);
+	for (const args of [
+		["doctor", "--scope", "toolchain", "--root", root, "--json"],
+		["--json", "--root", root, "doctor", "--scope", "toolchain"],
+	]) {
+		const result = runCli(args, { env: fake.env });
+		assert.equal(result.status, 0, result.stderr);
+		const output = parseSingleJson(result);
+		assert.deepEqual(
+			{
+				command: output.command,
+				ok: output.ok,
+				exitCode: output.exitCode,
+				root: output.root,
+				strict: output.strict,
+			},
+			{ command: "doctor", ok: true, exitCode: 0, root, strict: false }
+		);
+		assert.deepEqual(
+			new Set(output.checks.map((check) => check.id)),
+			new Set([
+				"toolchain.node",
+				"toolchain.pnpm",
+				"toolchain.yorkie",
+				"toolchain.docker",
+				"toolchain.compose",
+			])
+		);
+		assert.ok(output.checks.every((check) => check.scope === "toolchain"));
+		assert.ok(output.checks.every((check) => check.status === "pass"));
+		assert.deepEqual(output.summary, { pass: 5, warn: 0, fail: 0, skip: 0 });
+	}
+});
+
+test("doctor text output is human-readable", (t) => {
+	const root = createCodePairRoot(t, "doctor text");
+	const fake = createFakeToolchain(t);
+	const result = runCli(["doctor", "--root", root, "--scope", "toolchain"], {
+		env: fake.env,
+	});
+	assert.equal(result.status, 0, result.stderr);
+	assert.equal(result.stderr, "");
+	assert.match(result.stdout, /CodePair doctor/);
+	assert.match(result.stdout, /\[PASS\].*Node\.js/);
+	assert.match(result.stdout, /\[PASS\].*Yorkie CLI/);
+	assert.match(result.stdout, /Summary:\s+5 passed, 0 warnings, 0 failed, 0 skipped/);
+});
+
+test("doctor warnings are non-fatal unless strict mode is requested", (t) => {
+	const root = createCodePairRoot(t, "doctor strict");
+	writeEnvFiles(
+		root,
+		[
+			"DATABASE_URL=mongodb://localhost/codepair",
+			"GITHUB_CLIENT_ID=test-id",
+			"GITHUB_CLIENT_SECRET=secret",
+			"GITHUB_CALLBACK_URL=http://localhost:3000/auth/login/github",
+			"JWT_ACCESS_TOKEN_SECRET=strong-access-value",
+			"JWT_ACCESS_TOKEN_EXPIRATION_TIME=86400",
+			"JWT_REFRESH_TOKEN_SECRET=strong-refresh-value",
+			"JWT_REFRESH_TOKEN_EXPIRATION_TIME=604800",
+			"FRONTEND_BASE_URL=http://localhost:5173",
+			"YORKIE_API_ADDR=http://localhost:8080",
+			"YORKIE_PROJECT_SECRET_KEY=strong-yorkie-value",
+			"",
+		].join("\n"),
+		[
+			"VITE_API_ADDR=http://localhost:3000",
+			"VITE_YORKIE_API_ADDR=http://localhost:8080",
+			"VITE_YORKIE_API_KEY=public-key",
+			"",
+		].join("\n")
+	);
+
+	const lenient = runCli(["doctor", "--root", root, "--scope", "env", "--json"]);
+	assert.equal(lenient.status, 0, lenient.stderr);
+	const lenientOutput = parseSingleJson(lenient);
+	assert.equal(lenientOutput.ok, true);
+	assert.equal(lenientOutput.summary.warn, 1);
+	assert.equal(lenientOutput.summary.fail, 0);
+
+	const strict = runCli(["doctor", "--root", root, "--scope", "env", "--strict", "--json"]);
+	assert.equal(strict.status, 1, strict.stderr);
+	const strictOutput = parseSingleJson(strict);
+	assert.equal(strictOutput.ok, false);
+	assert.equal(strictOutput.exitCode, 1);
+	assert.equal(strictOutput.strict, true);
+	assert.equal(strictOutput.summary.warn, 1);
+});
+
+test("doctor required-tool failures exit 1 without strict mode", (t) => {
+	const root = createCodePairRoot(t, "doctor failure");
+	const fake = createFakeToolchain(t, {
+		tools: ["docker", "yorkie"],
+		inheritPath: false,
+	});
+	const result = runCli(["doctor", "--root", root, "--scope", "toolchain", "--json"], {
+		env: fake.env,
+	});
+	assert.equal(result.status, 1, result.stderr);
+	const output = parseSingleJson(result);
+	assert.equal(output.ok, false);
+	assert.equal(output.exitCode, 1);
+	assert.equal(output.summary.fail, 1);
+	assert.equal(output.checks.find((check) => check.id === "toolchain.pnpm")?.status, "fail");
+});
+
+test("doctor rejects unsupported pnpm and missing Docker/Compose", async (t) => {
+	await t.test("pnpm major version", (subtest) => {
+		const root = createCodePairRoot(subtest, "doctor pnpm version");
+		const fake = createFakeToolchain(subtest, { pnpmVersion: "10.1.0" });
+		const result = runCli(["doctor", "--root", root, "--scope", "toolchain", "--json"], {
+			env: fake.env,
+		});
+		assert.equal(result.status, 1, result.stderr);
+		const output = parseSingleJson(result);
+		assert.equal(output.checks.find(({ id }) => id === "toolchain.pnpm")?.status, "fail");
+	});
+
+	await t.test("Docker executables", (subtest) => {
+		const root = createCodePairRoot(subtest, "doctor docker missing");
+		const fake = createFakeToolchain(subtest, {
+			tools: ["pnpm", "yorkie"],
+			inheritPath: false,
+		});
+		const result = runCli(["doctor", "--root", root, "--scope", "toolchain", "--json"], {
+			env: fake.env,
+		});
+		assert.equal(result.status, 1, result.stderr);
+		const output = parseSingleJson(result);
+		assert.equal(output.summary.fail, 2);
+		for (const id of ["toolchain.docker", "toolchain.compose"]) {
+			assert.equal(output.checks.find((check) => check.id === id)?.status, "fail");
+		}
+	});
+});
+
+test("doctor compares Yorkie project keys and webhook with local configuration", (t) => {
+	const root = createCodePairRoot(t, "doctor yorkie");
+	const project = {
+		name: "codepair",
+		public_key: "pk_doctor_public",
+		secret_key: "sk_doctor_secret",
+		event_webhook_url: "http://host.docker.internal:3000/yorkie/document-events",
+		event_webhook_events: ["DocumentRootChanged"],
+	};
+	const fake = createFakeToolchain(t, { projects: [project] });
+	const env = {
+		...fake.env,
+		YORKIE_PROJECT_NAME: "codepair",
+		WEBHOOK_URL: project.event_webhook_url,
+	};
+	writeEnvFiles(
+		root,
+		`YORKIE_API_ADDR="http://localhost:8080"\nYORKIE_PROJECT_SECRET_KEY="${project.secret_key}"\n`,
+		`VITE_YORKIE_API_ADDR="http://localhost:8080"\nVITE_YORKIE_API_KEY="${project.public_key}"\n`
+	);
+
+	const matching = runCli(["doctor", "--root", root, "--scope", "yorkie", "--json"], { env });
+	assert.equal(matching.status, 0, matching.stderr);
+	const matchingOutput = parseSingleJson(matching);
+	assert.deepEqual(matchingOutput.summary, { pass: 5, warn: 0, fail: 0, skip: 0 });
+
+	writeEnvFiles(
+		root,
+		"YORKIE_API_ADDR=http://localhost:8080\nYORKIE_PROJECT_SECRET_KEY=wrong-secret\n",
+		"VITE_YORKIE_API_ADDR=http://localhost:8080\nVITE_YORKIE_API_KEY=wrong-public\n"
+	);
+	const mismatching = runCli(["doctor", "--root", root, "--scope", "yorkie", "--json"], { env });
+	assert.equal(mismatching.status, 1, mismatching.stderr);
+	const mismatchingOutput = parseSingleJson(mismatching);
+	for (const id of ["yorkie.backend-key", "yorkie.frontend-key"]) {
+		assert.equal(mismatchingOutput.checks.find((check) => check.id === id)?.status, "fail");
+	}
+});
+
+test("doctor reports invalid or divergent Yorkie configuration as a failed check", (t) => {
+	const root = createCodePairRoot(t, "doctor yorkie configuration");
+	const fake = createFakeToolchain(t, { projects: [existingProject()] });
+	writeEnvFiles(
+		root,
+		"YORKIE_API_ADDR=http://localhost:8080\nYORKIE_PROJECT_SECRET_KEY=secret\n",
+		"VITE_YORKIE_API_ADDR=http://localhost:9090\nVITE_YORKIE_API_KEY=public\n"
+	);
+
+	const divergent = runCli(["doctor", "--root", root, "--scope", "yorkie", "--json"], {
+		env: fake.env,
+	});
+	assert.equal(divergent.status, 1, divergent.stderr);
+	const divergentOutput = parseSingleJson(divergent);
+	assert.equal(divergentOutput.checks[0].id, "yorkie.configuration");
+	assert.match(divergentOutput.checks[0].message, /do not match/);
+	assert.deepEqual(fake.readInvocations(), []);
+
+	writeEnvFiles(
+		root,
+		"YORKIE_API_ADDR=http://localhost:8080\nYORKIE_PROJECT_SECRET_KEY=secret\n",
+		"VITE_YORKIE_API_ADDR=http://localhost:8080\nVITE_YORKIE_API_KEY=public\n"
+	);
+	const malformed = runCli(["doctor", "--root", root, "--scope", "yorkie", "--json"], {
+		env: { ...fake.env, WEBHOOK_URL: "http://alice:webhook-secret@[" },
+	});
+	assert.equal(malformed.status, 1, malformed.stderr);
+	const malformedOutput = parseSingleJson(malformed);
+	assert.equal(malformedOutput.checks[0].id, "yorkie.configuration");
+	assert.doesNotMatch(malformed.stdout, /alice|secret/);
+});

--- a/packages/cli/test/e2e/fixtures/fake-tool-bootstrap.cjs
+++ b/packages/cli/test/e2e/fixtures/fake-tool-bootstrap.cjs
@@ -1,0 +1,190 @@
+"use strict";
+
+const fs = require("node:fs");
+const path = require("node:path");
+
+const SUPPORTED_TOOLS = new Set(["docker", "git", "pnpm", "yorkie"]);
+const executableName = path.basename(process.argv0, path.extname(process.argv0)).toLowerCase();
+
+if (SUPPORTED_TOOLS.has(executableName)) {
+	// Node consumes its own --help/--version flags before preloads run. The fake
+	// executables are renamed Node binaries, so an empty forwarded argv represents
+	// the version/help probe used by the CLI.
+	const forwardedArgs = process.argv.slice(1);
+	if (forwardedArgs[0]) {
+		// Node resolves its first non-option argument as a script path. Recover the
+		// command token that the production CLI passed to the renamed executable.
+		forwardedArgs[0] = path.basename(forwardedArgs[0]);
+	}
+	runFakeTool(executableName, forwardedArgs.length > 0 ? forwardedArgs : ["--help"]);
+}
+
+module.exports = { runFakeTool };
+
+function environmentName(tool, suffix) {
+	return `FAKE_${tool.toUpperCase().replace(/[^A-Z0-9]/g, "_")}_${suffix}`;
+}
+
+function readJsonFile(file, fallback) {
+	if (!file || !fs.existsSync(file)) return fallback;
+	return JSON.parse(fs.readFileSync(file, "utf8"));
+}
+
+function writeJsonFile(file, value) {
+	if (!file) return;
+	fs.mkdirSync(path.dirname(file), { recursive: true });
+	fs.writeFileSync(file, `${JSON.stringify(value, null, 2)}\n`, "utf8");
+}
+
+function appendInvocation(tool, args, stdinBytes) {
+	const logFile = process.env.FAKE_TOOL_LOG;
+	if (!logFile) return;
+	const safeArgs = [];
+	let redactNext = false;
+	for (const arg of args) {
+		if (redactNext) {
+			safeArgs.push("[SECRET]");
+			redactNext = false;
+		} else if (arg === "-p" || arg === "--password" || arg === "--token") {
+			safeArgs.push(arg);
+			redactNext = true;
+		} else {
+			safeArgs.push(arg);
+		}
+	}
+	fs.mkdirSync(path.dirname(logFile), { recursive: true });
+	fs.appendFileSync(
+		logFile,
+		`${JSON.stringify({ tool, args: safeArgs, stdinBytes, cwd: process.cwd() })}\n`,
+		"utf8"
+	);
+}
+
+function projectState() {
+	const stateFile = process.env.FAKE_YORKIE_STATE;
+	if (stateFile && fs.existsSync(stateFile)) {
+		return readJsonFile(stateFile, { projects: [] });
+	}
+	const configured = process.env.FAKE_YORKIE_PROJECTS;
+	return { projects: configured ? JSON.parse(configured) : [] };
+}
+
+function saveProjectState(state) {
+	writeJsonFile(process.env.FAKE_YORKIE_STATE, state);
+}
+
+function flagValue(args, flag) {
+	const index = args.indexOf(flag);
+	return index >= 0 ? args[index + 1] : undefined;
+}
+
+function runYorkie(args, mode) {
+	if (args[0] === "--help" || args[0] === "help") {
+		process.stdout.write("Yorkie CLI fake\n");
+		return;
+	}
+	if (args[0] === "version" || args[0] === "--version") {
+		process.stdout.write("Yorkie: 0.7.12\n");
+		return;
+	}
+	if (args[0] === "login") {
+		process.stdout.write("Logged in\n");
+		return;
+	}
+	if (args[0] !== "project") {
+		process.stderr.write(`unexpected yorkie command: ${args.join(" ")}\n`);
+		process.exit(64);
+	}
+
+	if (args[1] === "ls") {
+		if (mode === "malformed-json") {
+			process.stdout.write("{ definitely-not-json\n");
+			return;
+		}
+		if (mode === "unexpected-json") {
+			process.stdout.write('{"notProjects":true}\n');
+			return;
+		}
+		process.stdout.write(`${JSON.stringify(projectState().projects)}\n`);
+		return;
+	}
+
+	if (args[1] === "create") {
+		const name = args[2];
+		if (!name) {
+			process.stderr.write("missing project name\n");
+			process.exit(64);
+		}
+		const state = projectState();
+		if (!state.projects.some((project) => project.name === name)) {
+			state.projects.push({
+				id: `fake-${state.projects.length + 1}`,
+				name,
+				public_key: process.env.FAKE_YORKIE_PUBLIC_KEY || "pk_fake_public",
+				secret_key: process.env.FAKE_YORKIE_SECRET_KEY || "sk_fake_secret",
+				event_webhook_url: "",
+				event_webhook_events: [],
+			});
+		}
+		saveProjectState(state);
+		process.stdout.write(
+			`${JSON.stringify(state.projects.find((project) => project.name === name))}\n`
+		);
+		return;
+	}
+
+	if (args[1] === "update") {
+		const name = args[2];
+		const state = projectState();
+		const project = state.projects.find((candidate) => candidate.name === name);
+		if (!project) {
+			process.stderr.write(`project not found: ${name}\n`);
+			process.exit(7);
+		}
+		project.event_webhook_url = flagValue(args, "--event-webhook-url") || "";
+		const event = flagValue(args, "--event-webhook-events-add");
+		project.event_webhook_events = event ? [event] : [];
+		saveProjectState(state);
+		process.stdout.write(`${JSON.stringify(project)}\n`);
+		return;
+	}
+
+	process.stderr.write(`unexpected yorkie project command: ${args.join(" ")}\n`);
+	process.exit(64);
+}
+
+function runFakeTool(tool, args) {
+	const mode = process.env[environmentName(tool, "MODE")] || "ok";
+	let stdin = "";
+	if (tool === "yorkie" && args[0] === "login" && process.env.FAKE_CAPTURE_STDIN === "1") {
+		stdin = fs.readFileSync(0, "utf8");
+	}
+	appendInvocation(tool, args, Buffer.byteLength(stdin));
+
+	const failOn = process.env[environmentName(tool, "FAIL_ON")];
+	if (mode === "fail" && (!failOn || failOn === args[0])) {
+		process.stderr.write(
+			process.env[environmentName(tool, "FAILURE_TEXT")] || `${tool} failed intentionally\n`
+		);
+		process.exit(Number(process.env[environmentName(tool, "EXIT_CODE")] || 9));
+	}
+
+	if (tool === "yorkie") {
+		runYorkie(args, mode);
+		process.exit(0);
+	}
+	if (tool === "docker") {
+		process.stdout.write(
+			args[0] === "compose" ? "Docker Compose version v2.29.0\n" : "Docker version 27.0.0\n"
+		);
+		process.exit(0);
+	}
+	if (tool === "pnpm") {
+		process.stdout.write(`${process.env.FAKE_PNPM_VERSION || "9.4.0"}\n`);
+		process.exit(0);
+	}
+	if (tool === "git") {
+		process.stdout.write("git version 2.45.0\n");
+		process.exit(0);
+	}
+}

--- a/packages/cli/test/e2e/helpers/cli-harness.mjs
+++ b/packages/cli/test/e2e/helpers/cli-harness.mjs
@@ -1,0 +1,246 @@
+import assert from "node:assert/strict";
+import { spawnSync } from "node:child_process";
+import {
+	chmodSync,
+	copyFileSync,
+	existsSync,
+	linkSync,
+	mkdirSync,
+	mkdtempSync,
+	readFileSync,
+	realpathSync,
+	rmSync,
+	writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { basename, delimiter, dirname, join, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import { sanitizedEnvironment } from "../../helpers/environment.mjs";
+
+const E2E_DIRECTORY = resolve(dirname(fileURLToPath(import.meta.url)), "..");
+const TEST_DIRECTORY = resolve(E2E_DIRECTORY, "..");
+export const CLI_DIRECTORY = resolve(TEST_DIRECTORY, "..");
+export const REPOSITORY_ROOT = resolve(CLI_DIRECTORY, "..", "..");
+export const FAKE_TOOL_BOOTSTRAP = resolve(E2E_DIRECTORY, "fixtures", "fake-tool-bootstrap.cjs");
+
+export function readCliPackage() {
+	return JSON.parse(readFileSync(resolve(CLI_DIRECTORY, "package.json"), "utf8"));
+}
+
+export function builtCliPath() {
+	const packageJson = readCliPackage();
+	const configuredBin = packageJson.bin;
+	const relativePath =
+		typeof configuredBin === "string"
+			? configuredBin
+			: configuredBin?.codepair || Object.values(configuredBin || {})[0];
+	assert.equal(typeof relativePath, "string", "package.json must expose a codepair bin");
+	const absolutePath = resolve(CLI_DIRECTORY, relativePath);
+	assert.ok(
+		existsSync(absolutePath),
+		`built CLI not found at ${absolutePath}; run the package build before tests`
+	);
+	return absolutePath;
+}
+
+export function temporaryDirectory(test, label = "workspace") {
+	const root = mkdtempSync(join(tmpdir(), `codepair-cli-${label}-`));
+	test.after(() => rmSync(root, { recursive: true, force: true }));
+	return root;
+}
+
+export function createCodePairRoot(test, label = "project") {
+	const parent = temporaryDirectory(test, label);
+	const root = join(parent, "code pair 한글");
+	mkdirSync(join(root, "packages", "backend"), { recursive: true });
+	mkdirSync(join(root, "packages", "frontend"), { recursive: true });
+	writeFileSync(
+		join(root, "package.json"),
+		`${JSON.stringify({ name: "codepair", private: true }, null, 2)}\n`,
+		"utf8"
+	);
+	writeFileSync(join(root, "pnpm-workspace.yaml"), 'packages:\n  - "packages/*"\n', "utf8");
+	return realpathSync(root);
+}
+
+function installWindowsFakeExecutable(binDirectory, tool, options) {
+	if (tool === "pnpm") {
+		writeFileSync(
+			join(binDirectory, "pnpm.cmd"),
+			`@echo off\r\necho ${options.pnpmVersion || "9.4.0"}\r\n`,
+			"utf8"
+		);
+		return;
+	}
+	const destination = join(binDirectory, `${tool}.exe`);
+	try {
+		linkSync(process.execPath, destination);
+	} catch {
+		copyFileSync(process.execPath, destination);
+	}
+}
+
+function installPosixFakeExecutable(binDirectory, tool) {
+	const destination = join(binDirectory, tool);
+	const bootstrap = JSON.stringify(FAKE_TOOL_BOOTSTRAP);
+	writeFileSync(
+		destination,
+		`#!/usr/bin/env node\nrequire(${bootstrap}).runFakeTool(${JSON.stringify(tool)}, process.argv.slice(2));\n`,
+		"utf8"
+	);
+	chmodSync(destination, 0o755);
+}
+
+function installFakeExecutable(binDirectory, tool, options) {
+	if (process.platform === "win32") {
+		installWindowsFakeExecutable(binDirectory, tool, options);
+		return;
+	}
+	installPosixFakeExecutable(binDirectory, tool);
+}
+
+export function createFakeToolchain(test, options = {}) {
+	const root = temporaryDirectory(test, "tools");
+	const binDirectory = join(root, "fake tools");
+	mkdirSync(binDirectory, { recursive: true });
+	for (const tool of options.tools || ["docker", "git", "pnpm", "yorkie"]) {
+		installFakeExecutable(binDirectory, tool, options);
+	}
+
+	const stateFile = join(root, "yorkie-state.json");
+	const logFile = join(root, "invocations.jsonl");
+	writeFileSync(
+		stateFile,
+		`${JSON.stringify({ projects: options.projects || [] }, null, 2)}\n`,
+		"utf8"
+	);
+
+	const requireOption = `--require=${FAKE_TOOL_BOOTSTRAP}`;
+	return {
+		root,
+		binDirectory,
+		stateFile,
+		logFile,
+		env: {
+			PATH:
+				options.inheritPath === false
+					? `${binDirectory}${delimiter}${dirname(process.execPath)}`
+					: `${binDirectory}${delimiter}${process.env.PATH || ""}`,
+			PATHEXT:
+				process.platform === "win32"
+					? `.EXE;.CMD;.BAT;${process.env.PATHEXT || ""}`
+					: process.env.PATHEXT,
+			NODE_OPTIONS: [process.env.NODE_OPTIONS, requireOption].filter(Boolean).join(" "),
+			FAKE_TOOL_LOG: logFile,
+			FAKE_YORKIE_STATE: stateFile,
+			FAKE_YORKIE_PUBLIC_KEY: options.publicKey || "pk_test_public",
+			FAKE_YORKIE_SECRET_KEY: options.secretKey || "sk_test_secret",
+			FAKE_CAPTURE_STDIN: options.captureStdin ? "1" : "0",
+			FAKE_PNPM_VERSION: options.pnpmVersion || "9.4.0",
+			GITHUB_CLIENT_ID: "test_github_client_id",
+			GITHUB_CLIENT_SECRET: "test_github_client_secret",
+		},
+		readState() {
+			return JSON.parse(readFileSync(stateFile, "utf8"));
+		},
+		readInvocations() {
+			if (!existsSync(logFile)) return [];
+			return readFileSync(logFile, "utf8")
+				.trim()
+				.split("\n")
+				.filter(Boolean)
+				.map((line) => JSON.parse(line));
+		},
+	};
+}
+
+export function runCli(args, options = {}) {
+	const result = spawnSync(process.execPath, [builtCliPath(), ...args], {
+		cwd: options.cwd || CLI_DIRECTORY,
+		env: sanitizedEnvironment({
+			NO_COLOR: "1",
+			FORCE_COLOR: "0",
+			CI: "1",
+			...options.env,
+		}),
+		encoding: "utf8",
+		input: options.input,
+		timeout: options.timeout || 30_000,
+		windowsHide: true,
+	});
+	if (result.error) throw result.error;
+	assert.equal(result.signal, null, `CLI terminated by ${result.signal}: ${result.stderr}`);
+	return {
+		status: result.status,
+		stdout: result.stdout || "",
+		stderr: result.stderr || "",
+	};
+}
+
+export function parseSingleJson(result) {
+	assert.equal(result.stderr, "", `expected no stderr, got: ${result.stderr}`);
+	const parsed = JSON.parse(result.stdout);
+	assert.equal(
+		result.stdout.trim(),
+		JSON.stringify(parsed, null, 2),
+		"JSON mode must emit exactly one pretty-printed JSON document"
+	);
+	return parsed;
+}
+
+export function existingProject(overrides = {}) {
+	return {
+		id: "fake-existing",
+		name: "codepair",
+		public_key: "pk_existing_public",
+		secret_key: "sk_existing_secret",
+		event_webhook_url: "http://host.docker.internal:3000/yorkie/document-events",
+		event_webhook_events: ["DocumentRootChanged"],
+		...overrides,
+	};
+}
+
+export function writeEnvFiles(root, backendContent, frontendContent) {
+	const backendPath = join(root, "packages", "backend", ".env.development");
+	const frontendPath = join(root, "packages", "frontend", ".env.development");
+	writeFileSync(backendPath, backendContent, "utf8");
+	writeFileSync(frontendPath, frontendContent, "utf8");
+	return { backendPath, frontendPath };
+}
+
+export function executableShimPath(prefix, name = "codepair") {
+	return process.platform === "win32"
+		? join(prefix, "node_modules", ".bin", `${name}.cmd`)
+		: join(prefix, "node_modules", ".bin", name);
+}
+
+export function runExecutable(file, args, options = {}) {
+	const command = process.platform === "win32" ? process.env.ComSpec || "cmd.exe" : file;
+	const commandArgs =
+		process.platform === "win32" ? ["/d", "/s", "/c", `"${file}"`, ...args] : args;
+	const result = spawnSync(command, commandArgs, {
+		cwd: options.cwd || dirname(file),
+		env: sanitizedEnvironment(options.env),
+		encoding: "utf8",
+		timeout: 30_000,
+		windowsHide: true,
+	});
+	if (result.error) throw result.error;
+	return {
+		status: result.status,
+		stdout: result.stdout || "",
+		stderr: result.stderr || "",
+	};
+}
+
+export function commandAvailable(command, args = ["--version"]) {
+	const result = spawnSync(command, args, {
+		encoding: "utf8",
+		windowsHide: true,
+	});
+	return !result.error && result.status === 0;
+}
+
+export function pathBasename(value) {
+	return basename(value).replace(/\.exe$/i, "");
+}

--- a/packages/cli/test/e2e/package.test.mjs
+++ b/packages/cli/test/e2e/package.test.mjs
@@ -1,0 +1,191 @@
+import assert from "node:assert/strict";
+import { spawnSync } from "node:child_process";
+import { existsSync, readFileSync, readdirSync, rmSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+import test from "node:test";
+
+import {
+	CLI_DIRECTORY,
+	REPOSITORY_ROOT,
+	createFakeToolchain,
+	executableShimPath,
+	existingProject,
+	readCliPackage,
+	runExecutable,
+	temporaryDirectory,
+} from "./helpers/cli-harness.mjs";
+import { sanitizedEnvironment } from "../helpers/environment.mjs";
+
+test("root scripts expose the CLI and preserve the setup:webhook alias", () => {
+	const rootPackage = JSON.parse(readFileSync(join(REPOSITORY_ROOT, "package.json"), "utf8"));
+	assert.equal(rootPackage.scripts.cli, "pnpm --filter=@codepair/cli dev");
+	assert.equal(rootPackage.scripts["setup:webhook"], "node scripts/setup-yorkie-webhook.js");
+});
+
+test("the legacy setup script delegates to the CLI", (t) => {
+	const environmentDirectory = temporaryDirectory(t, "legacy setup env");
+	const backendEnv = join(environmentDirectory, "backend.env");
+	const frontendEnv = join(environmentDirectory, "frontend.env");
+	const project = existingProject();
+	const fake = createFakeToolchain(t, {
+		projects: [project],
+		tools: ["yorkie"],
+	});
+
+	run(process.execPath, [join(REPOSITORY_ROOT, "scripts", "setup-yorkie-webhook.js")], {
+		cwd: REPOSITORY_ROOT,
+		env: {
+			...fake.env,
+			BACKEND_ENV_FILE: backendEnv,
+			FRONTEND_ENV_FILE: frontendEnv,
+			YORKIE_API_ADDR: "legacy-yorkie.example.test:8080",
+		},
+	});
+
+	assert.match(
+		readFileSync(backendEnv, "utf8"),
+		new RegExp(`YORKIE_PROJECT_SECRET_KEY="${project.secret_key}"`)
+	);
+	assert.match(
+		readFileSync(frontendEnv, "utf8"),
+		new RegExp(`VITE_YORKIE_API_KEY="${project.public_key}"`)
+	);
+	assert.doesNotMatch(
+		readFileSync(backendEnv, "utf8"),
+		/YORKIE_API_ADDR|DATABASE_URL|GITHUB_CLIENT_ID/
+	);
+	assert.doesNotMatch(readFileSync(frontendEnv, "utf8"), /VITE_YORKIE_API_ADDR|VITE_API_ADDR/);
+	assert.equal(
+		fake.readState().projects[0].event_webhook_url,
+		"http://localhost:3000/yorkie/document-events"
+	);
+	const login = fake.readInvocations().find(({ args }) => args[0] === "login");
+	assert.ok(login.args.includes("--insecure"));
+});
+
+test("the legacy setup script preserves file addresses and its localhost default", (t) => {
+	const environmentDirectory = temporaryDirectory(t, "legacy setup addresses");
+	const backendEnv = join(environmentDirectory, "backend.env");
+	const frontendEnv = join(environmentDirectory, "frontend.env");
+	writeFileSync(backendEnv, "YORKIE_API_ADDR=http://backend.example.test:8080\nKEEP=backend\n");
+	writeFileSync(
+		frontendEnv,
+		"VITE_YORKIE_API_ADDR=http://frontend.example.test:9090\nKEEP=frontend\n"
+	);
+	const fake = createFakeToolchain(t, {
+		projects: [existingProject()],
+		tools: ["yorkie"],
+	});
+
+	run(process.execPath, [join(REPOSITORY_ROOT, "scripts", "setup-yorkie-webhook.js")], {
+		cwd: REPOSITORY_ROOT,
+		env: {
+			...fake.env,
+			BACKEND_ENV_FILE: backendEnv,
+			FRONTEND_ENV_FILE: frontendEnv,
+		},
+	});
+
+	assert.match(readFileSync(backendEnv, "utf8"), /YORKIE_API_ADDR=http:\/\/backend\.example/);
+	assert.match(
+		readFileSync(frontendEnv, "utf8"),
+		/VITE_YORKIE_API_ADDR=http:\/\/frontend\.example/
+	);
+	const login = fake.readInvocations().find(({ args }) => args[0] === "login");
+	assert.equal(login.args[login.args.indexOf("--rpc-addr") + 1], "localhost:8080");
+});
+
+function run(command, args, options = {}) {
+	const useWindowsCommandShell = process.platform === "win32" && command === "npm";
+	const spawnedCommand = useWindowsCommandShell ? process.env.ComSpec || "cmd.exe" : command;
+	const spawnedArgs = useWindowsCommandShell ? ["/d", "/s", "/c", command, ...args] : args;
+	const result = spawnSync(spawnedCommand, spawnedArgs, {
+		cwd: options.cwd || CLI_DIRECTORY,
+		env: sanitizedEnvironment(options.env),
+		encoding: "utf8",
+		timeout: 120_000,
+		windowsHide: true,
+	});
+	if (result.error) throw result.error;
+	assert.equal(
+		result.status,
+		0,
+		`${command} ${args.join(" ")} failed\nstdout:\n${result.stdout}\nstderr:\n${result.stderr}`
+	);
+	return result;
+}
+
+function collectFiles(root, relativeDirectory = "") {
+	const paths = [];
+	for (const entry of readdirSync(join(root, relativeDirectory), { withFileTypes: true })) {
+		const relativePath = relativeDirectory ? `${relativeDirectory}/${entry.name}` : entry.name;
+		if (entry.isDirectory()) paths.push(...collectFiles(root, relativePath));
+		else paths.push(relativePath);
+	}
+	return paths;
+}
+
+test("the npm tarball contains the built binary and installs as codepair", (t) => {
+	const packDirectory = temporaryDirectory(t, "pack output");
+	const installDirectory = temporaryDirectory(t, "pack install");
+	rmSync(join(CLI_DIRECTORY, "dist"), { recursive: true, force: true });
+	run("npm", ["pack", "--pack-destination", packDirectory]);
+	const artifacts = readdirSync(packDirectory).filter((name) => name.endsWith(".tgz"));
+	assert.equal(artifacts.length, 1);
+	const artifact = join(packDirectory, artifacts[0]);
+	assert.ok(existsSync(artifact), `missing packed artifact ${artifact}`);
+
+	run(
+		"npm",
+		[
+			"install",
+			"--offline",
+			"--ignore-scripts",
+			"--no-audit",
+			"--no-fund",
+			"--prefix",
+			installDirectory,
+			artifact,
+		],
+		{ cwd: installDirectory }
+	);
+
+	const installedPackageDirectory = join(installDirectory, "node_modules", "@codepair", "cli");
+	const packageJsonPath = join(installedPackageDirectory, "package.json");
+	const installed = JSON.parse(readFileSync(packageJsonPath, "utf8"));
+	const expected = readCliPackage();
+	assert.equal(installed.name, "@codepair/cli");
+	assert.equal(installed.version, expected.version);
+	assert.equal(installed.bin.codepair, "dist/cli.js");
+	const paths = new Set(collectFiles(installedPackageDirectory));
+	for (const expectedPath of ["package.json", "LICENSE", "README.md", "dist/cli.js"]) {
+		assert.ok(paths.has(expectedPath), `missing packaged file ${expectedPath}`);
+	}
+	assert.ok(!paths.has("dist/index.js"));
+	assert.ok(![...paths].some((path) => path.endsWith(".d.ts")));
+	assert.ok(![...paths].some((path) => path.startsWith("src/")));
+	assert.ok(![...paths].some((path) => path.startsWith("test/")));
+
+	const executable = executableShimPath(installDirectory);
+	assert.ok(existsSync(executable), `missing installed executable ${executable}`);
+	const version = runExecutable(executable, ["--version"]);
+	assert.equal(version.status, 0, version.stderr);
+	assert.equal(version.stderr, "");
+	assert.equal(version.stdout.trim(), expected.version);
+	const help = runExecutable(executable, ["--help"]);
+	assert.equal(help.status, 0, help.stderr);
+	assert.match(help.stdout, /Usage:\s+codepair/);
+
+	const deepImport = spawnSync(
+		process.execPath,
+		["--input-type=module", "--eval", "import('@codepair/cli/dist/core/url.js')"],
+		{
+			cwd: installDirectory,
+			env: sanitizedEnvironment(),
+			encoding: "utf8",
+			windowsHide: true,
+		}
+	);
+	assert.notEqual(deepImport.status, 0);
+	assert.match(deepImport.stderr, /ERR_PACKAGE_PATH_NOT_EXPORTED/);
+});

--- a/packages/cli/test/e2e/setup.test.mjs
+++ b/packages/cli/test/e2e/setup.test.mjs
@@ -1,0 +1,466 @@
+import assert from "node:assert/strict";
+import {
+	chmodSync,
+	copyFileSync,
+	existsSync,
+	readdirSync,
+	readFileSync,
+	statSync,
+	writeFileSync,
+} from "node:fs";
+import { join } from "node:path";
+import test from "node:test";
+
+import {
+	createCodePairRoot,
+	createFakeToolchain,
+	existingProject,
+	parseSingleJson,
+	REPOSITORY_ROOT,
+	runCli,
+	temporaryDirectory,
+	writeEnvFiles,
+} from "./helpers/cli-harness.mjs";
+
+const DEFAULT_WEBHOOK = "http://host.docker.internal:3000/yorkie/document-events";
+
+function setupArguments(root, extra = []) {
+	return ["setup", "yorkie", "--root", root, "--yes", "--json", ...extra];
+}
+
+function invocationCommands(fake) {
+	return fake
+		.readInvocations()
+		.filter(({ tool }) => tool === "yorkie")
+		.map(({ args }) => args.slice(0, 3).join(" "));
+}
+
+test("setup reuses an existing configured project and writes both env files", (t) => {
+	const root = createCodePairRoot(t, "existing project");
+	const project = existingProject();
+	const fake = createFakeToolchain(t, { projects: [project] });
+
+	const result = runCli(setupArguments(root), { env: fake.env });
+	assert.equal(result.status, 0, result.stderr);
+	const output = parseSingleJson(result);
+	assert.deepEqual(
+		{
+			command: output.command,
+			ok: output.ok,
+			exitCode: output.exitCode,
+			root: output.root,
+			dryRun: output.dryRun,
+			changed: output.changed,
+		},
+		{
+			command: "setup yorkie",
+			ok: true,
+			exitCode: 0,
+			root,
+			dryRun: false,
+			changed: true,
+		}
+	);
+	const backend = readFileSync(join(root, "packages", "backend", ".env.development"), "utf8");
+	const frontend = readFileSync(join(root, "packages", "frontend", ".env.development"), "utf8");
+	assert.match(backend, new RegExp(`YORKIE_PROJECT_SECRET_KEY="${project.secret_key}"`));
+	assert.match(backend, /YORKIE_API_ADDR="http:\/\/localhost:8080"/);
+	assert.doesNotMatch(backend, /test_github_client_id|test_github_client_secret/);
+	assert.match(frontend, new RegExp(`VITE_YORKIE_API_KEY="${project.public_key}"`));
+	assert.match(frontend, /VITE_YORKIE_API_ADDR="http:\/\/localhost:8080"/);
+	assert.equal(output.actions.find(({ id }) => id === "yorkie.project")?.status, "unchanged");
+	assert.equal(output.actions.find(({ id }) => id === "yorkie.webhook")?.status, "unchanged");
+	assert.ok(!invocationCommands(fake).some((command) => command === "project create codepair"));
+	assert.ok(!invocationCommands(fake).some((command) => command === "project update codepair"));
+});
+
+test("setup creates and configures a missing Yorkie project", (t) => {
+	const root = createCodePairRoot(t, "missing project");
+	const fake = createFakeToolchain(t, {
+		projects: [],
+		publicKey: "pk_created_public",
+		secretKey: "sk_created_secret",
+	});
+
+	const result = runCli(setupArguments(root), { env: fake.env });
+	assert.equal(result.status, 0, result.stderr);
+	const output = parseSingleJson(result);
+	const state = fake.readState();
+	assert.equal(state.projects.length, 1);
+	assert.deepEqual(
+		{
+			name: state.projects[0].name,
+			url: state.projects[0].event_webhook_url,
+			events: state.projects[0].event_webhook_events,
+		},
+		{
+			name: "codepair",
+			url: DEFAULT_WEBHOOK,
+			events: ["DocumentRootChanged"],
+		}
+	);
+	assert.equal(output.actions.find(({ id }) => id === "yorkie.project")?.status, "changed");
+	assert.equal(output.actions.find(({ id }) => id === "yorkie.webhook")?.status, "changed");
+	assert.match(
+		readFileSync(join(root, "packages", "backend", ".env.development"), "utf8"),
+		/YORKIE_PROJECT_SECRET_KEY="sk_created_secret"/
+	);
+	assert.match(
+		readFileSync(join(root, "packages", "frontend", ".env.development"), "utf8"),
+		/VITE_YORKIE_API_KEY="pk_created_public"/
+	);
+});
+
+test("missing development env files are seeded from each package example", (t) => {
+	const root = createCodePairRoot(t, "env examples");
+	const project = existingProject();
+	const fake = createFakeToolchain(t, { projects: [project] });
+	copyFileSync(
+		join(REPOSITORY_ROOT, "packages", "backend", ".env.example"),
+		join(root, "packages", "backend", ".env.example")
+	);
+	copyFileSync(
+		join(REPOSITORY_ROOT, "packages", "frontend", ".env.example"),
+		join(root, "packages", "frontend", ".env.example")
+	);
+
+	const result = runCli(setupArguments(root), { env: fake.env });
+	assert.equal(result.status, 0, result.stderr);
+	const backend = readFileSync(join(root, "packages", "backend", ".env.development"), "utf8");
+	const frontend = readFileSync(join(root, "packages", "frontend", ".env.development"), "utf8");
+	assert.match(backend, /DATABASE_URL=mongodb:\/\/localhost:27017\/codepair/);
+	assert.match(backend, /^GITHUB_CLIENT_ID=$/m);
+	assert.match(backend, /^OPENAI_API_KEY=$/m);
+	assert.match(backend, /YORKIE_PROJECT_SECRET_KEY="sk_existing_secret"/);
+	assert.match(frontend, /^VITE_API_ADDR=http:\/\/localhost:3000$/m);
+	assert.match(frontend, /VITE_YORKIE_API_KEY="pk_existing_public"/);
+});
+
+test("setup is idempotent after the first successful run", (t) => {
+	const root = createCodePairRoot(t, "idempotent");
+	const fake = createFakeToolchain(t, { projects: [] });
+	const args = setupArguments(root);
+
+	const first = runCli(args, { env: fake.env });
+	assert.equal(first.status, 0, first.stderr);
+	assert.equal(parseSingleJson(first).changed, true);
+	const backendPath = join(root, "packages", "backend", ".env.development");
+	const frontendPath = join(root, "packages", "frontend", ".env.development");
+	const firstBackend = readFileSync(backendPath, "utf8");
+	const firstFrontend = readFileSync(frontendPath, "utf8");
+
+	const second = runCli(args, { env: fake.env });
+	assert.equal(second.status, 0, second.stderr);
+	const output = parseSingleJson(second);
+	assert.equal(output.changed, false);
+	assert.equal(readFileSync(backendPath, "utf8"), firstBackend);
+	assert.equal(readFileSync(frontendPath, "utf8"), firstFrontend);
+	assert.equal((firstBackend.match(/^YORKIE_PROJECT_SECRET_KEY=/gm) || []).length, 1);
+	assert.equal((firstFrontend.match(/^VITE_YORKIE_API_KEY=/gm) || []).length, 1);
+	assert.equal(fake.readState().projects.length, 1);
+	assert.ok(
+		output.actions
+			.filter(({ id }) => id !== "verify")
+			.every(({ status }) => status === "unchanged")
+	);
+});
+
+test("setup reuses a consistent Yorkie address from existing env files", (t) => {
+	const root = createCodePairRoot(t, "existing Yorkie address");
+	const project = existingProject();
+	const fake = createFakeToolchain(t, { projects: [project] });
+	const paths = writeEnvFiles(
+		root,
+		"UNRELATED=keep\nYORKIE_API_ADDR=https://yorkie.example.test\n",
+		"VITE_YORKIE_API_ADDR=https://yorkie.example.test\n"
+	);
+
+	const result = runCli(setupArguments(root), { env: fake.env });
+	assert.equal(result.status, 0, result.stderr);
+	assert.match(readFileSync(paths.backendPath, "utf8"), /UNRELATED=keep\n/);
+	assert.match(
+		readFileSync(paths.backendPath, "utf8"),
+		/YORKIE_API_ADDR="https:\/\/yorkie\.example\.test:443"/
+	);
+	const login = fake.readInvocations().find(({ args }) => args[0] === "login");
+	assert.equal(login.args[login.args.indexOf("--rpc-addr") + 1], "yorkie.example.test:443");
+	assert.ok(!login.args.includes("--insecure"));
+});
+
+test("setup refuses conflicting existing Yorkie addresses without an explicit selection", (t) => {
+	const root = createCodePairRoot(t, "conflicting Yorkie addresses");
+	const fake = createFakeToolchain(t, { projects: [existingProject()] });
+	writeEnvFiles(
+		root,
+		"YORKIE_API_ADDR=http://localhost:8080\n",
+		"VITE_YORKIE_API_ADDR=http://localhost:9090\n"
+	);
+
+	const result = runCli(setupArguments(root), { env: fake.env });
+	assert.equal(result.status, 2);
+	assert.equal(parseSingleJson(result).error.code, "CONFLICTING_YORKIE_ADDRESSES");
+	assert.deepEqual(fake.readInvocations(), []);
+});
+
+test("doctor can verify setup with custom project, webhook, RPC, and env paths", (t) => {
+	const root = createCodePairRoot(t, "custom setup doctor");
+	const fake = createFakeToolchain(t, { projects: [] });
+	const projectName = "codepair-custom";
+	const webhookUrl = "http://host.docker.internal:3000/custom-yorkie-events";
+	const backendEnv = "config/backend.env";
+	const frontendEnv = "config/frontend.env";
+
+	const setup = runCli(
+		setupArguments(root, [
+			"--rpc-addr",
+			"localhost:9090",
+			"--project",
+			projectName,
+			"--webhook-url",
+			webhookUrl,
+			"--backend-env",
+			backendEnv,
+			"--frontend-env",
+			frontendEnv,
+		]),
+		{ env: fake.env }
+	);
+	assert.equal(setup.status, 0, setup.stderr);
+
+	const doctor = runCli(
+		[
+			"doctor",
+			"--root",
+			root,
+			"--scope",
+			"yorkie",
+			"--project",
+			projectName,
+			"--webhook-url",
+			webhookUrl,
+			"--backend-env",
+			backendEnv,
+			"--frontend-env",
+			frontendEnv,
+			"--json",
+		],
+		{ env: fake.env }
+	);
+	assert.equal(doctor.status, 0, doctor.stderr);
+	assert.deepEqual(parseSingleJson(doctor).summary, {
+		pass: 5,
+		warn: 0,
+		fail: 0,
+		skip: 0,
+	});
+
+	const projectListCalls = fake
+		.readInvocations()
+		.filter(({ args }) => args[0] === "project" && args[1] === "ls");
+	assert.ok(projectListCalls.length >= 3);
+	for (const { args } of projectListCalls) {
+		assert.equal(args[args.indexOf("--rpc-addr") + 1], "localhost:9090");
+	}
+});
+
+test("non-TTY setup requires explicit confirmation and --yes bypasses it", (t) => {
+	const root = createCodePairRoot(t, "confirmation");
+	const fake = createFakeToolchain(t, { projects: [existingProject()] });
+
+	const refused = runCli(["setup", "yorkie", "--root", root, "--json"], {
+		env: fake.env,
+	});
+	assert.equal(refused.status, 2);
+	const refusedOutput = parseSingleJson(refused);
+	assert.equal(refusedOutput.error.code, "CONFIRMATION_REQUIRED");
+	assert.equal(existsSync(join(root, "packages", "backend", ".env.development")), false);
+	assert.ok(
+		fake
+			.readInvocations()
+			.filter(({ tool }) => tool === "yorkie")
+			.every(({ args }) => args[0] === "--help")
+	);
+
+	const accepted = runCli(setupArguments(root), { env: fake.env });
+	assert.equal(accepted.status, 0, accepted.stderr);
+	assert.equal(parseSingleJson(accepted).ok, true);
+});
+
+test("dry-run reports a plan without prompting or mutating state", (t) => {
+	const root = createCodePairRoot(t, "dry run");
+	const fake = createFakeToolchain(t, { projects: [] });
+	const result = runCli(["setup", "yorkie", "--root", root, "--dry-run", "--json"], {
+		env: fake.env,
+	});
+
+	assert.equal(result.status, 0, result.stderr);
+	const output = parseSingleJson(result);
+	assert.equal(output.dryRun, true);
+	assert.equal(output.changed, true);
+	assert.ok(output.actions.every(({ status }) => status === "planned"));
+	assert.deepEqual(fake.readState(), { projects: [] });
+	assert.equal(existsSync(join(root, "packages", "backend", ".env.development")), false);
+	assert.ok(
+		invocationCommands(fake).every((command) => command === "--help"),
+		"dry-run executed a mutating Yorkie command"
+	);
+});
+
+test("password stdin and command failures never expose secrets", (t) => {
+	const root = createCodePairRoot(t, "secret redaction");
+	const fake = createFakeToolchain(t, { projects: [existingProject()] });
+	const password = "uniquely-sensitive-password-48319";
+	const result = runCli(setupArguments(root, ["--password-stdin"]), {
+		env: {
+			...fake.env,
+			FAKE_YORKIE_MODE: "fail",
+			FAKE_YORKIE_FAIL_ON: "login",
+			FAKE_YORKIE_FAILURE_TEXT: `authentication failed for ${password}\n`,
+		},
+		input: `${password}\n`,
+	});
+
+	assert.equal(result.status, 1);
+	const output = parseSingleJson(result);
+	assert.equal(output.error.code, "COMMAND_FAILED");
+	assert.match(output.error.message, /\[REDACTED\]/);
+	assert.doesNotMatch(result.stdout, new RegExp(password));
+	assert.doesNotMatch(result.stderr, new RegExp(password));
+	assert.doesNotMatch(JSON.stringify(fake.readInvocations()), new RegExp(password));
+	const login = fake.readInvocations().find(({ args }) => args[0] === "login");
+	assert.equal(login.args[login.args.indexOf("-p") + 1], "[SECRET]");
+	assert.equal(existsSync(join(root, "packages", "backend", ".env.development")), false);
+});
+
+test("Yorkie failures and malformed JSON preserve existing env files", async (t) => {
+	for (const scenario of [
+		{
+			label: "login failure",
+			env: {
+				FAKE_YORKIE_MODE: "fail",
+				FAKE_YORKIE_FAIL_ON: "login",
+			},
+			expectedCode: "COMMAND_FAILED",
+		},
+		{
+			label: "malformed json",
+			env: { FAKE_YORKIE_MODE: "malformed-json" },
+			expectedCode: "INVALID_YORKIE_PROJECT_JSON",
+		},
+	]) {
+		await t.test(scenario.label, (subtest) => {
+			const root = createCodePairRoot(subtest, scenario.label);
+			const fake = createFakeToolchain(subtest, {
+				projects: [existingProject()],
+			});
+			const backend = "# keep backend\nUNCHANGED=backend\n";
+			const frontend = "# keep frontend\nUNCHANGED=frontend\n";
+			const paths = writeEnvFiles(root, backend, frontend);
+
+			const result = runCli(setupArguments(root), {
+				env: { ...fake.env, ...scenario.env },
+			});
+			assert.equal(result.status, 1);
+			const output = parseSingleJson(result);
+			assert.equal(output.error.code, scenario.expectedCode);
+			assert.equal(readFileSync(paths.backendPath, "utf8"), backend);
+			assert.equal(readFileSync(paths.frontendPath, "utf8"), frontend);
+		});
+	}
+});
+
+test("env updates are atomic, preserve content style, deduplicate keys, and stay private", (t) => {
+	const root = createCodePairRoot(t, "atomic env");
+	const project = existingProject();
+	const fake = createFakeToolchain(t, { projects: [project] });
+	const paths = writeEnvFiles(
+		root,
+		"# backend comment\r\nUNRELATED=keep-me\r\nOPENAI_API_KEY=keep-existing\r\nYORKIE_API_ADDR=https://old.example.test\r\nYORKIE_PROJECT_SECRET_KEY=old\r\nYORKIE_PROJECT_SECRET_KEY=duplicate\r\n",
+		"# frontend comment\r\nOTHER=preserved\r\nVITE_YORKIE_API_ADDR=https://old.example.test\r\nVITE_YORKIE_API_KEY=old\r\n"
+	);
+	if (process.platform !== "win32") {
+		chmodSync(paths.backendPath, 0o600);
+		chmodSync(paths.frontendPath, 0o600);
+	}
+
+	const result = runCli(setupArguments(root, ["--rpc-addr", "localhost:8080"]), {
+		env: fake.env,
+	});
+	assert.equal(result.status, 0, result.stderr);
+	const backend = readFileSync(paths.backendPath, "utf8");
+	const frontend = readFileSync(paths.frontendPath, "utf8");
+	assert.match(backend, /# backend comment\r\nUNRELATED=keep-me\r\n/);
+	assert.match(backend, /OPENAI_API_KEY=keep-existing\r\n/);
+	assert.match(frontend, /# frontend comment\r\nOTHER=preserved\r\n/);
+	assert.equal((backend.match(/^YORKIE_PROJECT_SECRET_KEY=/gm) || []).length, 1);
+	assert.equal((frontend.match(/^VITE_YORKIE_API_KEY=/gm) || []).length, 1);
+	assert.match(backend, new RegExp(`YORKIE_PROJECT_SECRET_KEY="${project.secret_key}"\\r\\n`));
+	assert.match(frontend, new RegExp(`VITE_YORKIE_API_KEY="${project.public_key}"\\r\\n`));
+	assert.match(backend, /YORKIE_API_ADDR="http:\/\/localhost:8080"\r\n/);
+	assert.match(frontend, /VITE_YORKIE_API_ADDR="http:\/\/localhost:8080"\r\n/);
+	assert.ok(!backend.replaceAll("\r\n", "").includes("\n"));
+	assert.ok(!frontend.replaceAll("\r\n", "").includes("\n"));
+	if (process.platform !== "win32") {
+		assert.equal(statSync(paths.backendPath).mode & 0o777, 0o600);
+		assert.equal(statSync(paths.frontendPath).mode & 0o777, 0o600);
+	}
+	for (const directory of [
+		join(root, "packages", "backend"),
+		join(root, "packages", "frontend"),
+	]) {
+		assert.ok(!readdirSync(directory).some((name) => name.endsWith(".tmp")));
+	}
+});
+
+test("user-controlled project names are passed as argv and cannot invoke a shell", (t) => {
+	const root = createCodePairRoot(t, "shell injection");
+	const fake = createFakeToolchain(t, { projects: [] });
+	const markerDirectory = temporaryDirectory(t, "injection marker");
+	const marker = join(markerDirectory, "must-not-exist");
+	const projectName =
+		process.platform === "win32"
+			? `project & echo owned > ${marker}`
+			: `project; touch ${marker}`;
+
+	const result = runCli(setupArguments(root, ["--project", projectName]), {
+		env: fake.env,
+	});
+	assert.equal(result.status, 0, result.stderr);
+	assert.equal(existsSync(marker), false, "a project name was interpreted by a shell");
+	assert.equal(fake.readState().projects[0].name, projectName);
+	const create = fake
+		.readInvocations()
+		.find(({ args }) => args[0] === "project" && args[1] === "create");
+	assert.equal(create.args[2], projectName);
+});
+
+test("insecure remote Yorkie addresses require an explicit override", (t) => {
+	const root = createCodePairRoot(t, "transport safety");
+	const fake = createFakeToolchain(t, { projects: [existingProject()] });
+	const remote = "yorkie.example.test:8080";
+
+	const refused = runCli(setupArguments(root, ["--rpc-addr", remote]), {
+		env: fake.env,
+	});
+	assert.equal(refused.status, 2);
+	assert.equal(parseSingleJson(refused).error.code, "INSECURE_REMOTE_REFUSED");
+	assert.deepEqual(fake.readInvocations(), []);
+
+	const allowed = runCli(
+		setupArguments(root, ["--rpc-addr", remote, "--allow-insecure-remote"]),
+		{ env: fake.env }
+	);
+	assert.equal(allowed.status, 0, allowed.stderr);
+	assert.equal(parseSingleJson(allowed).ok, true);
+	const insecureLogin = fake.readInvocations().find(({ args }) => args[0] === "login");
+	assert.ok(insecureLogin.args.includes("--insecure"));
+
+	const secureRoot = createCodePairRoot(t, "secure transport");
+	const secureFake = createFakeToolchain(t, { projects: [existingProject()] });
+	const secure = runCli(setupArguments(secureRoot, ["--rpc-addr", remote, "--secure"]), {
+		env: secureFake.env,
+	});
+	assert.equal(secure.status, 0, secure.stderr);
+	const secureLogin = secureFake.readInvocations().find(({ args }) => args[0] === "login");
+	assert.ok(!secureLogin.args.includes("--insecure"));
+});

--- a/packages/cli/test/helpers/environment.mjs
+++ b/packages/cli/test/helpers/environment.mjs
@@ -1,0 +1,37 @@
+export const CLI_CONFIGURATION_VARIABLES = [
+	"BACKEND_ENV_FILE",
+	"CODEPAIR_LEGACY_SETUP",
+	"CODEPAIR_ROOT",
+	"DATABASE_URL",
+	"FRONTEND_BASE_URL",
+	"FRONTEND_ENV_FILE",
+	"GITHUB_CALLBACK_URL",
+	"GITHUB_CLIENT_ID",
+	"GITHUB_CLIENT_SECRET",
+	"JWT_ACCESS_TOKEN_EXPIRATION_TIME",
+	"JWT_ACCESS_TOKEN_SECRET",
+	"JWT_REFRESH_TOKEN_EXPIRATION_TIME",
+	"JWT_REFRESH_TOKEN_SECRET",
+	"MINIO_ENDPOINT",
+	"OLLAMA_HOST_URL",
+	"QDRANT_URL",
+	"VITE_API_ADDR",
+	"VITE_YORKIE_API_ADDR",
+	"VITE_YORKIE_API_KEY",
+	"WEBHOOK_URL",
+	"YORKIE_API_ADDR",
+	"YORKIE_PASSWORD",
+	"YORKIE_PROJECT_NAME",
+	"YORKIE_PROJECT_SECRET_KEY",
+	"YORKIE_USERNAME",
+];
+
+export function sanitizedEnvironment(overrides = {}) {
+	const environment = { ...process.env };
+	for (const name of CLI_CONFIGURATION_VARIABLES) delete environment[name];
+	return { ...environment, ...overrides };
+}
+
+export function clearCliConfigurationEnvironment() {
+	for (const name of CLI_CONFIGURATION_VARIABLES) delete process.env[name];
+}

--- a/packages/cli/test/integration/yorkie.test.mjs
+++ b/packages/cli/test/integration/yorkie.test.mjs
@@ -1,0 +1,101 @@
+import assert from "node:assert/strict";
+import { randomUUID } from "node:crypto";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import test from "node:test";
+
+import { createCodePairRoot, parseSingleJson, runCli } from "../e2e/helpers/cli-harness.mjs";
+
+const rpcAddress = process.env.CODEPAIR_YORKIE_RPC_ADDR;
+const webhookUrl = "http://host.docker.internal:3000/yorkie/document-events";
+
+function setupArguments(root, projectName) {
+	return [
+		"setup",
+		"yorkie",
+		"--root",
+		root,
+		"--rpc-addr",
+		rpcAddress,
+		"--project",
+		projectName,
+		"--webhook-url",
+		webhookUrl,
+		"--yes",
+		"--json",
+	];
+}
+
+test(
+	"setup and doctor interoperate with a real Yorkie server",
+	{
+		skip: rpcAddress ? false : "Set CODEPAIR_YORKIE_RPC_ADDR to run this integration test.",
+		timeout: 60_000,
+	},
+	(t) => {
+		const root = createCodePairRoot(t, "real yorkie");
+		const projectName = `codepair-cli-${randomUUID().slice(0, 8)}`;
+		const env = {
+			OPENAI_API_KEY: "must-not-be-persisted",
+			YORKIE_PASSWORD: "admin",
+		};
+
+		const first = runCli(setupArguments(root, projectName), { env, timeout: 60_000 });
+		assert.equal(first.status, 0, first.stderr);
+		const firstOutput = parseSingleJson(first);
+		assert.equal(firstOutput.ok, true);
+		assert.equal(firstOutput.changed, true);
+		assert.equal(
+			firstOutput.actions.find(({ id }) => id === "yorkie.project")?.status,
+			"changed"
+		);
+		assert.equal(
+			firstOutput.actions.find(({ id }) => id === "yorkie.webhook")?.status,
+			"changed"
+		);
+
+		const backendEnv = readFileSync(
+			join(root, "packages", "backend", ".env.development"),
+			"utf8"
+		);
+		const frontendEnv = readFileSync(
+			join(root, "packages", "frontend", ".env.development"),
+			"utf8"
+		);
+		assert.match(backendEnv, /^YORKIE_PROJECT_SECRET_KEY="[^"]+"$/m);
+		assert.match(backendEnv, /^YORKIE_API_ADDR="http:\/\/127\.0\.0\.1:18080"$/m);
+		assert.doesNotMatch(backendEnv, /must-not-be-persisted/);
+		assert.match(frontendEnv, /^VITE_YORKIE_API_KEY="[^"]+"$/m);
+		assert.match(frontendEnv, /^VITE_YORKIE_API_ADDR="http:\/\/127\.0\.0\.1:18080"$/m);
+
+		const second = runCli(setupArguments(root, projectName), { env, timeout: 60_000 });
+		assert.equal(second.status, 0, second.stderr);
+		const secondOutput = parseSingleJson(second);
+		assert.equal(secondOutput.ok, true);
+		assert.equal(secondOutput.changed, false);
+
+		const doctor = runCli(
+			[
+				"doctor",
+				"--root",
+				root,
+				"--scope",
+				"yorkie",
+				"--project",
+				projectName,
+				"--webhook-url",
+				webhookUrl,
+				"--json",
+			],
+			{
+				env,
+				timeout: 60_000,
+			}
+		);
+		assert.equal(doctor.status, 0, doctor.stderr);
+		const doctorOutput = parseSingleJson(doctor);
+		assert.equal(doctorOutput.ok, true);
+		assert.deepEqual(doctorOutput.summary, { pass: 5, warn: 0, fail: 0, skip: 0 });
+		assert.ok(doctorOutput.checks.every(({ status }) => status === "pass"));
+	}
+);

--- a/packages/cli/test/unit/env-file.test.mjs
+++ b/packages/cli/test/unit/env-file.test.mjs
@@ -1,0 +1,48 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { parseEnv, updateEnvContent } from "../../dist/core/env-file.js";
+
+test("parseEnv reads exported, quoted, bare, and duplicate assignments", () => {
+	const parsed = parseEnv(
+		[
+			"# ignored",
+			'export DOUBLE="two words"',
+			"SINGLE='single value'",
+			"BARE=bare-value # trailing comment",
+			"EMPTY=",
+			"NOT AN ASSIGNMENT",
+			"DOUBLE=last-value",
+			"",
+		].join("\n")
+	);
+
+	assert.deepEqual(Object.fromEntries(parsed), {
+		DOUBLE: "last-value",
+		SINGLE: "single value",
+		BARE: "bare-value",
+		EMPTY: "",
+	});
+});
+
+test("updateEnvContent preserves CRLF and unrelated lines while replacing keys once", () => {
+	const original = "# heading\r\nKEEP=1\r\nTARGET=old\r\nTARGET=duplicate\r\n# footer\r\n";
+	const updated = updateEnvContent(original, {
+		TARGET: "new value",
+		ADDED: 'quote " and slash \\',
+	});
+
+	assert.equal(
+		updated,
+		'# heading\r\nKEEP=1\r\nTARGET="new value"\r\n# footer\r\n\r\nADDED="quote \\" and slash \\\\"\r\n'
+	);
+	assert.equal((updated.match(/^TARGET=/gm) || []).length, 1);
+	assert.ok(!updated.replaceAll("\r\n", "").includes("\n"));
+});
+
+test("updateEnvContent rejects invalid environment variable names", () => {
+	assert.throws(
+		() => updateEnvContent("", { "NOT-SAFE": "value" }),
+		/Invalid environment variable name/
+	);
+});

--- a/packages/cli/test/unit/options.test.mjs
+++ b/packages/cli/test/unit/options.test.mjs
@@ -1,0 +1,122 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { parseDoctorOptions } from "../../dist/commands/doctor.js";
+import { parseSetupYorkieOptions } from "../../dist/commands/setup-yorkie.js";
+import { extractGlobalOptions, optionValue } from "../../dist/core/args.js";
+import { clearCliConfigurationEnvironment } from "../helpers/environment.mjs";
+
+clearCliConfigurationEnvironment();
+
+test("global options are extracted before or after command tokens", () => {
+	assert.deepEqual(
+		extractGlobalOptions(["--json", "doctor", "--root=/tmp/code pair", "--scope", "env", "-h"]),
+		{
+			options: {
+				json: true,
+				help: true,
+				version: false,
+				root: "/tmp/code pair",
+			},
+			remaining: ["doctor", "--scope", "env"],
+		}
+	);
+	assert.throws(
+		() => extractGlobalOptions(["doctor", "--root"]),
+		(error) => error?.code === "MISSING_OPTION_VALUE"
+	);
+});
+
+test("doctor options validate scope and strict mode", () => {
+	assert.deepEqual(
+		parseDoctorOptions(
+			[
+				"--scope=yorkie",
+				"--strict",
+				"--rpc-addr",
+				"https://yorkie.example.test",
+				"--project=custom",
+				"--webhook-url",
+				"https://codepair.example.test/yorkie/events",
+				"--backend-env=config/backend.env",
+				"--frontend-env",
+				"config/frontend.env",
+			],
+			"/repo"
+		),
+		{
+			root: "/repo",
+			strict: true,
+			scope: "yorkie",
+			rpcAddress: "https://yorkie.example.test",
+			projectName: "custom",
+			webhookUrl: "https://codepair.example.test/yorkie/events",
+			backendEnvPath: "config/backend.env",
+			frontendEnvPath: "config/frontend.env",
+		}
+	);
+	assert.throws(
+		() => parseDoctorOptions(["--scope", "invalid"]),
+		(error) => error?.code === "INVALID_SCOPE" && error?.exitCode === 2
+	);
+	assert.throws(
+		() => parseDoctorOptions(["--rpc-addr", "http://alice:rpc-secret@["]),
+		(error) => error?.code === "INVALID_RPC_ADDRESS" && error?.exitCode === 2
+	);
+});
+
+test("setup options parse string, boolean, equals, and alias forms", () => {
+	const options = parseSetupYorkieOptions(
+		[
+			"--rpc-addr=example.test:8080",
+			"--project",
+			"project 한글",
+			"--username",
+			"operator",
+			"--webhook-url=https://example.test/hook",
+			"--backend-env",
+			"path with spaces/backend.env",
+			"--frontend-env=frontend.env",
+			"--password-stdin",
+			"--secure",
+			"--allow-insecure-remote",
+			"-y",
+			"--dry-run",
+		],
+		"/repo"
+	);
+	assert.deepEqual(options, {
+		root: "/repo",
+		rpcAddress: "example.test:8080",
+		projectName: "project 한글",
+		username: "operator",
+		passwordFromStdin: true,
+		webhookUrl: "https://example.test/hook",
+		backendEnvPath: "path with spaces/backend.env",
+		frontendEnvPath: "frontend.env",
+		secure: true,
+		allowInsecureRemote: true,
+		legacyEnvironmentKeysOnly: false,
+		yes: true,
+		dryRun: true,
+	});
+	assert.throws(
+		() => parseSetupYorkieOptions(["--insecure", "--secure"]),
+		(error) => error?.code === "CONFLICTING_TRANSPORT_OPTIONS" && error?.exitCode === 2
+	);
+});
+
+test("optionValue validates missing and inline values", () => {
+	assert.deepEqual(optionValue(["--name=value"], 0, "--name"), {
+		value: "value",
+		consumed: 1,
+	});
+	assert.deepEqual(optionValue(["--name", "value"], 0, "--name"), {
+		value: "value",
+		consumed: 2,
+	});
+	assert.throws(
+		() => optionValue(["--name"], 0, "--name"),
+		(error) => error?.code === "MISSING_OPTION_VALUE"
+	);
+});

--- a/packages/cli/test/unit/process-services.test.mjs
+++ b/packages/cli/test/unit/process-services.test.mjs
@@ -1,0 +1,65 @@
+import assert from "node:assert/strict";
+import { mkdtemp, readFile, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import test from "node:test";
+
+import { parseHostPort } from "../../dist/adapters/network.js";
+import { httpCheck } from "../../dist/checks/services.js";
+import { CommandRunner } from "../../dist/core/process.js";
+
+test(
+	"CommandRunner escalates and settles when a child ignores SIGTERM",
+	{ timeout: 5_000 },
+	async () => {
+		const directory = await mkdtemp(join(tmpdir(), "codepair-process-test-"));
+		const marker = join(directory, "sigterm-received");
+		const script = [
+			'import fs from "node:fs";',
+			'process.on("SIGTERM", () => fs.writeFileSync(process.argv[1], "received"));',
+			"setInterval(() => undefined, 1_000);",
+		].join("");
+		const startedAt = Date.now();
+
+		try {
+			await assert.rejects(
+				new CommandRunner().run(
+					process.execPath,
+					["--input-type=module", "--eval", script, marker],
+					{
+						timeoutMs: 750,
+					}
+				),
+				(error) => error?.code === "COMMAND_TIMEOUT"
+			);
+			assert.ok(Date.now() - startedAt < 3_000, "timeout should always settle promptly");
+			if (process.platform !== "win32") {
+				assert.equal(await readFile(marker, "utf8"), "received");
+			}
+		} finally {
+			await rm(directory, { recursive: true, force: true });
+		}
+	}
+);
+
+test("service HTTP checks reject URL credentials without exposing them", async () => {
+	const check = await httpCheck(
+		"services.private",
+		"Private service",
+		"https://alice:s%40per-secret@example.test:8443/base",
+		"/health"
+	);
+	const serialized = JSON.stringify(check);
+
+	assert.equal(check.status, "fail");
+	assert.match(check.message, /must not contain URL credentials/);
+	assert.doesNotMatch(serialized, /alice|s%40per-secret|s@per-secret/);
+	assert.equal(check.details, undefined);
+});
+
+test("TCP endpoint parsing removes URL brackets from IPv6 socket hosts", () => {
+	assert.deepEqual(parseHostPort("http://[::1]:8080", 80), {
+		host: "::1",
+		port: 8080,
+	});
+});

--- a/packages/cli/test/unit/url-redact.test.mjs
+++ b/packages/cli/test/unit/url-redact.test.mjs
@@ -1,0 +1,96 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+	assertSafeTransport,
+	getRpcHost,
+	isLoopbackHost,
+	normalizeYorkieRpcEndpoint,
+	validateWebhookUrl,
+} from "../../dist/core/url.js";
+import { REDACTED, redactCommandArgs, redactText, redactValue } from "../../dist/core/redact.js";
+
+test("URL safety accepts loopback and secure transports but rejects plaintext remote login", () => {
+	assert.equal(getRpcHost("localhost:8080"), "localhost");
+	assert.equal(getRpcHost("https://yorkie.example.test:443"), "yorkie.example.test");
+	for (const host of ["localhost", "api.localhost", "127.0.0.1", "::1"]) {
+		assert.equal(isLoopbackHost(host), true, host);
+	}
+	assert.doesNotThrow(() => assertSafeTransport("localhost:8080", true, false));
+	assert.doesNotThrow(() => assertSafeTransport("yorkie.example.test:8080", false, false));
+	assert.doesNotThrow(() => assertSafeTransport("yorkie.example.test:8080", true, true));
+	assert.throws(
+		() => assertSafeTransport("yorkie.example.test:8080", true, false),
+		(error) => error?.code === "INSECURE_REMOTE_REFUSED" && error?.exitCode === 2
+	);
+});
+
+test("Yorkie RPC endpoints use canonical CLI and application forms", () => {
+	assert.deepEqual(normalizeYorkieRpcEndpoint("localhost:8080"), {
+		rpcAddress: "localhost:8080",
+		httpUrl: "http://localhost:8080",
+		secure: false,
+	});
+	assert.deepEqual(normalizeYorkieRpcEndpoint("yorkie.example.test"), {
+		rpcAddress: "yorkie.example.test:8080",
+		httpUrl: "http://yorkie.example.test:8080",
+		secure: false,
+	});
+	assert.deepEqual(normalizeYorkieRpcEndpoint("https://yorkie.example.test"), {
+		rpcAddress: "yorkie.example.test:443",
+		httpUrl: "https://yorkie.example.test:443",
+		secure: true,
+	});
+	assert.throws(
+		() => normalizeYorkieRpcEndpoint("http://yorkie.example.test", "secure"),
+		(error) => error?.code === "CONFLICTING_TRANSPORT_OPTIONS"
+	);
+	assert.throws(
+		() => normalizeYorkieRpcEndpoint("https://yorkie.example.test/path"),
+		(error) => error?.code === "INVALID_RPC_ADDRESS"
+	);
+});
+
+test("webhook validation allows HTTP(S) without embedded credentials", () => {
+	assert.equal(validateWebhookUrl("https://example.test/hook").protocol, "https:");
+	assert.throws(
+		() => validateWebhookUrl("file:///tmp/hook"),
+		(error) => error?.code === "INVALID_WEBHOOK_URL"
+	);
+	assert.throws(
+		() => validateWebhookUrl("https://user:pass@example.test/hook"),
+		(error) => error?.code === "WEBHOOK_CREDENTIALS_REFUSED"
+	);
+});
+
+test("malformed URLs never echo embedded credentials", () => {
+	for (const [input, operation] of [
+		["http://alice:rpc-secret@[", normalizeYorkieRpcEndpoint],
+		["http://alice:webhook-secret@[", validateWebhookUrl],
+	]) {
+		assert.throws(operation.bind(undefined, input), (error) => {
+			assert.doesNotMatch(error.message, /alice|secret/);
+			return true;
+		});
+	}
+});
+
+test("redaction covers known secrets, labeled values, command arguments, and object keys", () => {
+	const secret = "sensitive-value-123";
+	const text = redactText(`login ${secret} password=visible token=generic api_key:also-visible`, [
+		secret,
+	]);
+	assert.doesNotMatch(
+		text,
+		/sensitive-value-123|password=visible|token=generic|api_key:also-visible/
+	);
+	assert.match(text, new RegExp(REDACTED.replace(/[\[\]]/g, "\\$&")));
+	assert.deepEqual(
+		redactCommandArgs(["login", "-p", secret, "--token=abc", "--project", "codepair"]),
+		["login", "-p", REDACTED, `--token=${REDACTED}`, "--project", "codepair"]
+	);
+	assert.deepEqual(redactValue({ password: secret, nested: { apiKey: "abc", ok: 1 } }), {
+		password: REDACTED,
+		nested: { apiKey: REDACTED, ok: 1 },
+	});
+});

--- a/packages/cli/test/unit/yorkie-cli.test.mjs
+++ b/packages/cli/test/unit/yorkie-cli.test.mjs
@@ -1,0 +1,64 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { parseYorkieProjects } from "../../dist/adapters/yorkie-cli.js";
+
+test("parseYorkieProjects accepts snake_case arrays and comma-separated events", () => {
+	assert.deepEqual(
+		parseYorkieProjects(
+			JSON.stringify([
+				{
+					name: "codepair",
+					secret_key: "secret",
+					public_key: "public",
+					event_webhook_url: "https://example.test/hook",
+					event_webhook_events: "DocumentRootChanged, OtherEvent",
+				},
+			])
+		),
+		[
+			{
+				name: "codepair",
+				secretKey: "secret",
+				publicKey: "public",
+				eventWebhookUrl: "https://example.test/hook",
+				eventWebhookEvents: ["DocumentRootChanged", "OtherEvent"],
+			},
+		]
+	);
+});
+
+test("parseYorkieProjects accepts supported wrappers and camelCase fields", () => {
+	for (const wrapper of ["projects", "items", "data"]) {
+		const output = parseYorkieProjects(
+			JSON.stringify({
+				[wrapper]: [
+					{
+						name: wrapper,
+						secretKey: "secret",
+						publicKey: "public",
+						eventWebhookUrl: "http://localhost/hook",
+						eventWebhookEvents: ["DocumentRootChanged"],
+					},
+				],
+			})
+		);
+		assert.equal(output[0].name, wrapper);
+		assert.deepEqual(output[0].eventWebhookEvents, ["DocumentRootChanged"]);
+	}
+});
+
+test("parseYorkieProjects reports malformed and unexpected JSON", () => {
+	assert.throws(
+		() => parseYorkieProjects("{not-json"),
+		(error) => error?.code === "INVALID_YORKIE_PROJECT_JSON" && error?.exitCode === 1
+	);
+	assert.throws(
+		() => parseYorkieProjects('{"notProjects":true}'),
+		(error) => error?.code === "INVALID_YORKIE_PROJECT_OUTPUT"
+	);
+	assert.throws(
+		() => parseYorkieProjects('[{"public_key":"missing-name"}]'),
+		(error) => error?.code === "INVALID_YORKIE_PROJECT_OUTPUT"
+	);
+});

--- a/packages/cli/tsconfig.json
+++ b/packages/cli/tsconfig.json
@@ -1,0 +1,22 @@
+{
+	"compilerOptions": {
+		"target": "ES2022",
+		"module": "NodeNext",
+		"moduleResolution": "NodeNext",
+		"lib": ["ES2023"],
+		"types": ["node"],
+		"rootDir": "src",
+		"outDir": "dist",
+		"strict": true,
+		"noUncheckedIndexedAccess": true,
+		"noImplicitOverride": true,
+		"useUnknownInCatchVariables": true,
+		"verbatimModuleSyntax": true,
+		"isolatedModules": true,
+		"sourceMap": true,
+		"noEmitOnError": true,
+		"forceConsistentCasingInFileNames": true,
+		"skipLibCheck": true
+	},
+	"include": ["src/**/*.ts"]
+}

--- a/packages/frontend/.env.example
+++ b/packages/frontend/.env.example
@@ -1,0 +1,5 @@
+# Local CodePair services
+VITE_API_ADDR=http://localhost:3000
+VITE_YORKIE_API_ADDR=http://localhost:8080
+# The setup CLI writes the local Yorkie project public key.
+VITE_YORKIE_API_KEY=

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -191,6 +191,27 @@ importers:
         specifier: ^4.2.0
         version: 4.2.0
 
+  packages/cli:
+    devDependencies:
+      '@types/node':
+        specifier: ^22.19.7
+        version: 22.19.7
+      '@typescript-eslint/eslint-plugin':
+        specifier: ^8.53.0
+        version: 8.53.0(@typescript-eslint/parser@8.53.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3)
+      '@typescript-eslint/parser':
+        specifier: ^8.53.0
+        version: 8.53.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3)
+      eslint:
+        specifier: ^9.39.2
+        version: 9.39.2(jiti@2.6.1)
+      prettier:
+        specifier: ^3.8.0
+        version: 3.8.0
+      typescript:
+        specifier: ^5.9.3
+        version: 5.9.3
+
   packages/codemirror:
     dependencies:
       '@codemirror/commands':

--- a/scripts/setup-yorkie-webhook.js
+++ b/scripts/setup-yorkie-webhook.js
@@ -1,213 +1,39 @@
 #!/usr/bin/env node
 
-const { execSync } = require("child_process");
-const fs = require("fs");
-const path = require("path");
+const { spawnSync } = require("node:child_process");
+const { resolve } = require("node:path");
 
-const YORKIE_API_ADDR = process.env.YORKIE_API_ADDR || "localhost:8080";
-const YORKIE_PROJECT_NAME = process.env.YORKIE_PROJECT_NAME || "codepair";
-const YORKIE_USERNAME = process.env.YORKIE_USERNAME || "admin";
-const YORKIE_PASSWORD = process.env.YORKIE_PASSWORD || "admin";
-const WEBHOOK_URL =
-  process.env.WEBHOOK_URL ||
-  "http://localhost:3000/yorkie/document-events";
-const BACKEND_ENV_FILE =
-  process.env.BACKEND_ENV_FILE ||
-  path.join(__dirname, "..", "packages", "backend", ".env.development");
-const FRONTEND_ENV_FILE =
-  process.env.FRONTEND_ENV_FILE ||
-  path.join(__dirname, "..", "packages", "frontend", ".env.development");
+const repositoryRoot = resolve(__dirname, "..");
+const legacyEnvironment = {
+  ...process.env,
+  CODEPAIR_LEGACY_SETUP: "1",
+  YORKIE_API_ADDR: process.env.YORKIE_API_ADDR || "localhost:8080",
+  WEBHOOK_URL:
+    process.env.WEBHOOK_URL || "http://localhost:3000/yorkie/document-events",
+};
+const cliArguments = [
+  "cli",
+  "setup",
+  "yorkie",
+  "--yes",
+  "--allow-insecure-remote",
+];
+const command =
+  process.platform === "win32" ? process.env.ComSpec || "cmd.exe" : "pnpm";
+const commandArguments =
+  process.platform === "win32"
+    ? ["/d", "/s", "/c", "pnpm cli setup yorkie --yes --allow-insecure-remote"]
+    : cliArguments;
+const result = spawnSync(command, commandArguments, {
+  cwd: repositoryRoot,
+  env: legacyEnvironment,
+  stdio: "inherit",
+  shell: false,
+});
 
-function execCommand(command) {
-  try {
-    return execSync(command, {
-      encoding: "utf8",
-      stdio: ["pipe", "pipe", "pipe"],
-    });
-  } catch (error) {
-    throw new Error(
-      `Command failed: ${command}\n${error.stderr || error.message}`,
-    );
-  }
+if (result.error) {
+  console.error(`Unable to start the CodePair CLI: ${result.error.message}`);
+  process.exitCode = 1;
+} else {
+  process.exitCode = result.status ?? 1;
 }
-
-async function setupYorkieWebhook() {
-  console.log("🔧 Setting up Yorkie webhook...");
-
-  try {
-    // Check if yorkie CLI is installed
-    try {
-      execSync("which yorkie", { stdio: "ignore" });
-    } catch {
-      console.error("❌ Yorkie CLI is not installed");
-      console.error(
-        "💡 Install it with: brew tap yorkie-team/yorkie && brew install yorkie",
-      );
-      console.error(
-        "   Or download from: https://github.com/yorkie-team/yorkie/releases",
-      );
-      process.exit(1);
-    }
-
-    // Login to Yorkie
-    console.log(`🔑 Logging in to Yorkie (${YORKIE_API_ADDR})...`);
-    execCommand(
-      `yorkie login -u ${YORKIE_USERNAME} -p ${YORKIE_PASSWORD} --insecure --rpc-addr ${YORKIE_API_ADDR}`,
-    );
-    console.log("✅ Logged in successfully");
-
-    // Get project info
-    console.log(`📡 Fetching project '${YORKIE_PROJECT_NAME}' information...`);
-    const projectListOutput = execCommand(
-      "yorkie project ls --verbose --output json",
-    );
-
-    // Parse JSON output
-    let projects;
-    try {
-      projects = JSON.parse(projectListOutput);
-    } catch (error) {
-      console.error("❌ Failed to parse project list JSON:");
-      console.error(projectListOutput);
-      throw error;
-    }
-
-    // Find the target project
-    let project = projects.find((p) => p.name === YORKIE_PROJECT_NAME);
-
-    if (!project) {
-      console.log(`📦 Project '${YORKIE_PROJECT_NAME}' not found. Creating...`);
-      try {
-        execCommand(`yorkie project create ${YORKIE_PROJECT_NAME}`);
-        console.log(`✅ Project '${YORKIE_PROJECT_NAME}' created successfully`);
-
-        // Fetch project list again to get the new project
-        const updatedProjectListOutput = execCommand(
-          "yorkie project ls --verbose --output json",
-        );
-        projects = JSON.parse(updatedProjectListOutput);
-        project = projects.find((p) => p.name === YORKIE_PROJECT_NAME);
-
-        if (!project) {
-          console.error(
-            `❌ Failed to find newly created project '${YORKIE_PROJECT_NAME}'`,
-          );
-          process.exit(1);
-        }
-      } catch (error) {
-        console.error(`❌ Failed to create project '${YORKIE_PROJECT_NAME}'`);
-        console.error(error.message);
-        process.exit(1);
-      }
-    } else {
-      console.log(`✅ Project '${YORKIE_PROJECT_NAME}' found`);
-    }
-
-    const secretKey = project.secret_key;
-    const publicKey = project.public_key;
-
-    if (!secretKey) {
-      console.error("❌ Secret key not found in project data");
-      console.error("Project data:", JSON.stringify(project, null, 2));
-      process.exit(1);
-    }
-
-    if (!publicKey) {
-      console.error("❌ Public key not found in project data");
-      console.error("Project data:", JSON.stringify(project, null, 2));
-      process.exit(1);
-    }
-
-    console.log(
-      `✅ Project secret key retrieved: ${secretKey.substring(0, 10)}...`,
-    );
-    console.log(
-      `✅ Project public key retrieved: ${publicKey.substring(0, 10)}...`,
-    );
-
-    // Update webhook using CLI (only if different from current)
-    const currentWebhookUrl = project.event_webhook_url || "";
-    if (currentWebhookUrl !== WEBHOOK_URL) {
-      console.log(`🔗 Setting webhook URL: ${WEBHOOK_URL}`);
-      execCommand(
-        `yorkie project update ${YORKIE_PROJECT_NAME} --event-webhook-url "${WEBHOOK_URL}" --event-webhook-events-add "DocumentRootChanged"`,
-      );
-      console.log(
-        "✅ Webhook configured successfully with DocumentRootChanged event",
-      );
-    } else {
-      console.log(`✅ Webhook URL already set: ${WEBHOOK_URL}`);
-      console.log(
-        `🔗 Updating webhook methods to include DocumentRootChanged...`,
-      );
-      execCommand(
-        `yorkie project update ${YORKIE_PROJECT_NAME} --event-webhook-events-add "DocumentRootChanged"`,
-      );
-      console.log("✅ Webhook methods updated");
-    }
-
-    // Update .env file
-    console.log(`📝 Updating ${BACKEND_ENV_FILE}...`);
-
-    let envContent = "";
-    if (fs.existsSync(BACKEND_ENV_FILE)) {
-      envContent = fs.readFileSync(BACKEND_ENV_FILE, "utf8");
-    } else {
-      const templatePath = path.join(__dirname, "..", "packages", "backend", ".env");
-      if (fs.existsSync(templatePath)) {
-        envContent = fs.readFileSync(templatePath, "utf8");
-      }
-    }
-
-    const secretKeyLine = `YORKIE_PROJECT_SECRET_KEY="${secretKey}"`;
-    if (envContent.includes("YORKIE_PROJECT_SECRET_KEY=")) {
-      envContent = envContent.replace(
-        /^YORKIE_PROJECT_SECRET_KEY=.*/m,
-        secretKeyLine,
-      );
-    } else {
-      envContent += `\n${secretKeyLine}\n`;
-    }
-
-    fs.writeFileSync(BACKEND_ENV_FILE, envContent);
-    console.log("✅ Backend .env file updated");
-
-    // Update frontend .env file
-    console.log(`📝 Updating ${FRONTEND_ENV_FILE}...`);
-
-    let frontendEnvContent = "";
-    if (fs.existsSync(FRONTEND_ENV_FILE)) {
-      frontendEnvContent = fs.readFileSync(FRONTEND_ENV_FILE, "utf8");
-    }
-
-    const publicKeyLine = `VITE_YORKIE_API_KEY="${publicKey}"`;
-    if (frontendEnvContent.includes("VITE_YORKIE_API_KEY=")) {
-      frontendEnvContent = frontendEnvContent.replace(
-        /^VITE_YORKIE_API_KEY=.*/m,
-        publicKeyLine,
-      );
-    } else {
-      frontendEnvContent += `\n${publicKeyLine}\n`;
-    }
-
-    fs.writeFileSync(FRONTEND_ENV_FILE, frontendEnvContent);
-    console.log("✅ Frontend .env file updated");
-
-    console.log("\n✨ Setup complete!");
-    console.log("\n📋 Next steps:");
-    console.log("  1. Start backend: pnpm backend start:dev");
-    console.log("  2. Start frontend: pnpm frontend dev");
-  } catch (error) {
-    console.error("❌ Error:", error.message);
-    console.error("\n💡 Make sure:");
-    console.error("  - Yorkie CLI is installed");
-    console.error("  - Docker containers are running");
-    console.error(`  - Yorkie server is accessible at ${YORKIE_API_ADDR}`);
-    console.error(
-      `  - Login credentials are correct (${YORKIE_USERNAME}:${YORKIE_PASSWORD})`,
-    );
-    process.exit(1);
-  }
-}
-
-setupYorkieWebhook();


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR adds a typed, repository-local CLI for setting up and diagnosing a CodePair development environment.

The primary contributor workflows are:

```sh
pnpm cli setup yorkie --yes
pnpm cli doctor
```

`setup yorkie` creates or reuses the selected Yorkie project, configures the `DocumentRootChanged` webhook, writes the Yorkie addresses and project keys to the development environment files, and verifies the resulting state. Missing environment files are seeded from checked-in examples. Re-running the command is idempotent.

`doctor` provides read-only checks for the supported toolchain, environment configuration, local services, and Yorkie project state. Both commands support structured JSON output and stable exit codes for automation.

The previous webhook script was difficult to extend safely because setup, process execution, environment-file mutation, and output handling were coupled in one untyped file. The new package separates argument parsing, process execution, Yorkie access, environment-file handling, diagnostics, networking, prompting, and output formatting into focused modules.

The CLI is intentionally:

- Private and repository-scoped; it is not an npm release or a production deployment tool.
- Dependency-free at runtime.
- Limited to contributor setup and diagnostics.
- Independent of the NestJS and frontend application lifecycles.

Compatibility and application boundaries:

- `pnpm setup:webhook` remains available and delegates to the new implementation.
- The compatibility path preserves its existing localhost RPC and webhook defaults, plaintext-remote behavior, and keys-only environment-file updates.
- The modern setup path updates only `YORKIE_API_ADDR`, `YORKIE_PROJECT_SECRET_KEY`, `VITE_YORKIE_API_ADDR`, and `VITE_YORKIE_API_KEY`. Existing comments, OAuth credentials, JWT settings, AI provider settings, storage configuration, and other values are preserved.
- No backend, frontend, CodeMirror, or UI runtime source files are changed.
- The only Compose behavior change is an additive `host.docker.internal` host-gateway mapping for local development, allowing the Yorkie container to reach the host backend.
- Frontend-only mode and `docker-compose-full.yml` are unchanged.

**Which issue(s) this PR fixes**:

NONE

**Special notes for your reviewer**:

Security and failure handling:

- External commands receive explicit argument arrays without interpolating user input into a shell command.
- Plaintext Yorkie login to a non-loopback address is rejected unless the caller explicitly opts in; TLS is supported through `--secure`.
- Non-interactive mutations require `--yes`, and `--dry-run` validates prerequisites and reports the plan without changing state.
- Passwords and known secret fields are redacted from human-readable and JSON diagnostics.
- Webhook URLs containing embedded credentials are rejected.
- Environment files are replaced atomically and use owner-only permissions where supported.
- Setup verifies Yorkie and local file postconditions before reporting success.

Yorkie currently accepts its password through `yorkie login -p`. `--password-stdin` keeps the password out of the CodePair command line, but the child Yorkie process may expose it briefly to same-host process inspection. This is documented, and setup should only be run on a trusted development machine.

Validation completed:

- `pnpm --filter=@codepair/cli verify`
  - Formatting, linting, and type checking passed.
  - 18 unit tests passed.
  - 35 deterministic end-to-end tests passed.
  - The E2E suite packs the package from a clean build, installs the tarball into a temporary prefix, executes the installed `codepair` binary, validates package contents, and confirms internal deep imports are blocked.
- Pinned real-Yorkie integration: 1 test passed, covering project setup, webhook configuration, an idempotent second run, and `doctor` verification from the written environment files.
- Backend and frontend formatting and builds passed.
- Frontend lint completed with no errors and one pre-existing Fast Refresh warning.
- CodeMirror and UI type checks passed.
- Both backend Docker Compose configurations passed `docker compose config`.

The real-Yorkie test validates the control-plane workflow. It does not start the complete CodePair application or assert delivery of an actual document-change webhook through the backend.

The dedicated CLI workflow covers Ubuntu/Node.js 22, macOS/Node.js 20, and Windows/Node.js 24. This covers every supported operating system and Node.js major without a nine-job Cartesian matrix. The Linux job additionally verifies both Compose files and runs against a checksum-verified Yorkie CLI archive and digest-pinned Yorkie server image.

**Does this PR introduce a user-facing change?**:

```release-note
Added a private contributor CLI for configuring and diagnosing CodePair's local Yorkie development environment.
```

**Additional documentation**:

```docs
- [Getting started]: README.md#command-line-interface
- [CLI usage and automation contract]: packages/cli/README.md
- [Design]: docs/design/cli.md
```

**Checklist**:

- [x] Added relevant tests or not required
- [x] Didn't break anything

🤖 Generated with OpenAI Codex.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added the CodePair command-line interface with Yorkie setup and diagnostic commands.
  * Added machine-readable JSON output, safety checks, environment configuration, and secure secret handling.
  * Added local development environment templates and a CLI development command.
  * Added automated cross-platform validation for formatting, linting, tests, packaging, and integrations.

* **Documentation**
  * Documented CLI installation, commands, options, setup behavior, diagnostics, and design details.
  * Updated development and release instructions.

* **Bug Fixes**
  * Preserved the existing webhook setup command through a compatibility wrapper.
  * Improved local Docker connectivity and environment-file updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->